### PR TITLE
Listen address smf variable

### DIFF
--- a/smf/nad.xml
+++ b/smf/nad.xml
@@ -20,14 +20,14 @@
         <envvar name='PATH' value='/usr/xpg4/bin:/usr/bin:/usr/sbin:/sbin:/usr/sfw/bin:/usr/local/bin:/opt/circonus/bin:/opt/omni/bin'/>
       </method_environment>
     </method_context>
-    <exec_method name='start' type='method' exec='/opt/circonus/sbin/nad -c /opt/circonus/etc/node-agent.d -p %{config/listen_ip}' timeout_seconds='60'>
+    <exec_method name='start' type='method' exec='/opt/circonus/sbin/nad -c /opt/circonus/etc/node-agent.d -p %{config/listen_address}' timeout_seconds='60'>
       <method_context>
         <method_credential user='nobody' group='other'/>
       </method_context>
     </exec_method>
     <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
       <property_group name='config' type='application'>
-        <propval name='listen_ip' type='astring' value='0.0.0.0:2609' />
+        <propval name='listen_address' type='astring' value='0.0.0.0:2609' />
       </property_group>
     <property_group name='startd' type='framework'>
       <propval name='duration' type='astring' value='child'/>


### PR DESCRIPTION
This change sets liste_address as an SMF variable in the manifest file, which means we can easily and programmatically configure the listen address and port for the nad service later.
