### PR TITLE
Added a --wipedebugdir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ so is safe to use while running normally.
 
  * --debugdir <string> Create debug files for each script and write them to this directory. Optional
 
+ * --wipedebugdir Wipe debug files clean before each write. Optional
+
 By default nad talks to the main Circonus installation.  You can also
 configure nad to talk to a Circonus Inside install with the following
 config options:

--- a/nad
+++ b/nad
@@ -65,6 +65,7 @@ var hostname = null;
 var brokerid = null
 var configfile = null;
 var debugdir = null;                        // if set, a dir to write debug logs to
+var wipedebugdir = false;                  // if true, wipe debug logs clean before each write
 var platform = process.platform;
 var is_windows = (platform === "win32");    // windows
 
@@ -101,6 +102,7 @@ function help(err) {
               "\t--brokerid\t\tID of the Circonus broker to configure the check on.\n" +
               "\t--configfile\t\tName of the file in the config directory to use for Circonus configuration.\n" +
               "\t--debugdir\t\tCreate debug files for each script and write them to this directory.\n" +
+              "\t--wipedebugdir\t\tWipe debug files clean before each write.\n" +
               "\t--apihost\t\tOverride the host for the Circonus API server (default: api.circonus.com)\n" +
               "\t--apiport\t\tOverride the port for the Circonus API server (default: 443)\n" +
               "\t--apipath\t\tOverride the path for the Circonus API server (default: /v2)\n" +
@@ -280,6 +282,7 @@ for(var i=2; i<process.argv.length; i++) {
     case "--brokerid": brokerid = process.argv[++i]; break;
     case "--configfile": configfile = fs.realpathSync(process.argv[++i]); break;
     case "--debugdir": debugdir = process.argv[++i]; break;
+    case "--wipedebugdir": wipedebugdir = true; ++i; break;
     case "--apihost": api_options['host'] = process.argv[++i]; break;
     case "--apiport": api_options['port'] = process.argv[++i]; break;
     case "--apipath": api_options['path'] = process.argv[++i]; break;
@@ -603,6 +606,9 @@ function run_script(d, cb, req, args, instance) {
     if (debugdir) {
       var debug_file = debugdir + "/" + d.name + ".nad_debug";
       try {
+	if (wipedebugdir) {
+          init_debug(d.name);
+        }
         var output = "-----START RECORD-----\n" + proc_data.lines.join('\n') + "\n-----END RECORD-----\n";
         fs.appendFile(debug_file, output);
       }

--- a/nad.8
+++ b/nad.8
@@ -3,7 +3,7 @@
 nad \- node\-agent daemon
 .SH SYNOPSIS
 .B nad
-[\-h] [\-i] [\-u uid] [\-c configdir] [\-p [ip:]port] [\-s [ip:]sslport] [\-v] [\-\-debugdir debugdir]
+[\-h] [\-i] [\-u uid] [\-c configdir] [\-p [ip:]port] [\-s [ip:]sslport] [\-v] [\-\-debugdir debugdir] [\-\-wipedebugdir]
 .SH DESCRIPTION
 The node\-agent daemon provides a simple mechanism to expose
 systems and application metrics to external onlookers. It
@@ -73,6 +73,12 @@ file in the
 Writes debug files for each script in the directory specified. Existing files
 will be removed when nad starts up and new files will be created. Files will
 be in the format of <name of script>.nad_debug.
+.TP
+\-\-wipedebugdir
+Existing debug files for each script in the
+.I configdir
+directory will be removed before each write. This allows only the most recent
+debug output to persist on disk.
 .SH SCRIPT OUTPUT
 The executable programs that you place in the
 .I configdir


### PR DESCRIPTION
I've added an option to delete the debug log before it is written to.  This will allow someone to persist to disk only the most recent debug logs from the most recent run of the nad script.

This would be very helpful in a variety of situations where you'd want to collect debug logs over a longer period of time without worrying about them growing too large.