### PR TITLE
Fix 'file is not defined'

### DIFF
--- a/nad
+++ b/nad
@@ -738,7 +738,7 @@ function run_scripts(req, res, which) {
     // if nothing was passed in which, with every script
 
     // first work out how many scripts we're going to wait to run
-    for(file in scripts) {
+    for(var file in scripts) {
       if ( which && file != which ) continue;
       req.nad_run_count++;
     }
@@ -747,7 +747,7 @@ function run_scripts(req, res, which) {
     // then when it returns in the callback populate set with
     // the result.  Keep track of how many scripts are left to run
     //
-    for(file in scripts) {
+    for(var file in scripts) {
       if ( which && file != which ) continue;
       init_script(scripts[file], req, function(d, results, name) {
         req.nad_run_count--;


### PR DESCRIPTION
When not specifying a particular run file nad bombs because of missing
var declarations.

I'm not sure how no one hit this before, it's been a long time since I've written
any JavaScript. Here's the exact error I saw:

```
/opt/circonus/sbin/nad:741
    for(file in scripts) {
                ^
ReferenceError: file is not defined
    at run_scripts (/opt/circonus/sbin/nad:741:17)
    at IncomingMessage.<anonymous> (/opt/circonus/sbin/nad:785:14)
    at IncomingMessage.emit (events.js:92:17)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
[ Jul  3 12:36:05 Stopping because all processes in service exited. ]
```