### PR TITLE
Teach nad how to register multiple checks in the same config

### DIFF
--- a/node_modules/nad_circapi/index.js
+++ b/node_modules/nad_circapi/index.js
@@ -68,6 +68,10 @@ function configure_checks() {
     for (var check in config.checks) {
         configure_check(config.checks[check]);
     }
+
+    // If someone specifies a single check, it should override the checks in
+    // the array.
+    configure_check(config.check);
 }
 
 function configure_check(chk_config) {

--- a/node_modules/nad_circapi/index.js
+++ b/node_modules/nad_circapi/index.js
@@ -50,7 +50,7 @@ exports.configure = function (tok, targ, host, brok, conf, options) {
 
 function main() {
     get_config_sync();
-    configure_check();
+    configure_checks();
 }
 
 function get_config_sync() {
@@ -64,15 +64,20 @@ function get_config_sync() {
     }
 }
 
-function configure_check() {
-    var metrics     = [],
-        chk_config  = config.check;
+function configure_checks() {
+    for (var check in config.checks) {
+        configure_check(config.checks[check]);
+    }
+}
 
-    for ( var idx in config.check.metrics.numeric ) {
-        metrics.push({"name": config.check.metrics.numeric[idx], "type": "numeric"});
-    }    
-    for ( var idx in config.check.metrics.text ) {
-        metrics.push({"name": config.check.metrics.text[idx], "type": "text"});
+function configure_check(chk_config) {
+    var metrics     = [];
+
+    for ( var idx in chk_config.metrics.numeric ) {
+        metrics.push({"name": chk_config.metrics.numeric[idx], "type": "numeric"});
+    }
+    for ( var idx in chk_config.metrics.text ) {
+        metrics.push({"name": chk_config.metrics.text[idx], "type": "text"});
     }
 
     // We pulled the base config out of the configfile, now add anything
@@ -102,8 +107,10 @@ function configure_check() {
             }
             else {
                 var lookup = {};
-                // We are going to compare the metrics we got back from the API with what we wanted.  The API check_bundle endpoint
-                // does some deduplication on check creation and we might have been handed back an already created check which is 
+                // We are going to compare the metrics we got back from the
+                // API with what we wanted.  The API check_bundle endpoint
+                // does some deduplication on check creation and we might
+                // have been handed back an already created check which is
                 // just missing some additional metrics we want.
                 for ( var idx in body.metrics ) {
                     if ( ! lookup[body.metrics[idx].type] ) {
@@ -120,8 +127,10 @@ function configure_check() {
                     }
                 }
 
-                // If we were missing any metrics in the return, we will need to update our existing check.  The missing metrics were
-                // added to the body, so PUT that back at the API using the object's _cid as the endpoint
+                // If we were missing any metrics in the return, we will need
+                // to update our existing check.  The missing metrics were
+                // added to the body, so PUT that back at the API using the
+                // object's _cid as the endpoint
                 if ( needs_update ) {
                     api.put(
                         body._cid,

--- a/node_modules/nad_circapi/index.js
+++ b/node_modules/nad_circapi/index.js
@@ -65,13 +65,17 @@ function get_config_sync() {
 }
 
 function configure_checks() {
-    for (var check in config.checks) {
-        configure_check(config.checks[check]);
+    if (config.checks) {
+        for (var check in config.checks) {
+            configure_check(config.checks[check]);
+        }
     }
 
-    // If someone specifies a single check, it should override the checks in
-    // the array.
-    configure_check(config.check);
+    if (config.check) {
+        // If someone specifies a single check, it should override the checks in
+        // the array.
+        configure_check(config.check);
+    }
 }
 
 function configure_check(chk_config) {


### PR DESCRIPTION
It's still necessary to have nad listen on multiple ports (i.e. -p 2611 -p 2612), but this allows a single config to register multiple check bundles.