### PR TITLE
Fix network counters on OmniOS

### DIFF
--- a/plugins/illumos/if.sh
+++ b/plugins/illumos/if.sh
@@ -7,7 +7,7 @@ fi
 kstat_opts="-p -m"
 distro=`awk 'NR==1 { print $1 }' /etc/release`
 case $distro in
-  SmartOS|Joyent)
+  SmartOS|Joyent|OmniOS)
     kstat_opts="-p -c net -n"
     ;;
 esac


### PR DESCRIPTION
Fix network counters on OmniOS.  Previously this was broken and counters such as ``rbytes`` were returning zero because it was missing the appropriate arguments to ``kstat(1M)``.

This could be seen by:

```sh
$ sh if.sh | grep rbyte
ixgbe0:intrbytes        L       15669598882
ixgbe0:rbytes   L       21196111324
ixgbe0:intrbytes        L       15807058256
ixgbe0:rbytes   L       21511223999
ixgbe0:rbytes   L       21196111324
ixgbe0:rbytes   L       21511223999
ixgbe0:intrbytes        L       0
ixgbe0:rbytes   L       0
```

After the fix:

```sh
$ sh if.sh
link:0:ixgbe0:brdcstrcv L       22315
link:0:ixgbe0:brdcstxmt L       676
link:0:ixgbe0:collisions        L       0
link:0:ixgbe0:ierrors   L       10344
link:0:ixgbe0:ifspeed   L       1000000000
link:0:ixgbe0:ipackets  L       31136805
link:0:ixgbe0:ipackets64        L       31136805
link:0:ixgbe0:link_duplex       L       2
link:0:ixgbe0:link_state        L       1
link:0:ixgbe0:multircv  L       79146
link:0:ixgbe0:multixmt  L       11
link:0:ixgbe0:norcvbuf  L       0
link:0:ixgbe0:noxmtbuf  L       0
link:0:ixgbe0:obytes    L       203251171
link:0:ixgbe0:obytes64  L       4498218467
link:0:ixgbe0:oerrors   L       0
link:0:ixgbe0:opackets  L       8072737
link:0:ixgbe0:opackets64        L       8072742
link:0:ixgbe0:rbytes    L       4056812670
link:0:ixgbe0:rbytes64  L       42711518334
link:0:ixgbe0:unknowns  L       78837
```

Bandwidth graphs are much happier looking now.