### PR TITLE
Corrected: free -b truncates values for total memory to 10 digits. 

### DIFF
--- a/plugins/linux/vm.sh
+++ b/plugins/linux/vm.sh
@@ -4,18 +4,18 @@ print_vm() {
     printf "%s\`%s\tL\t%s\n" $1 $2 $3
 }
 
-MEM=($(free -b | grep ^Mem:))
+MEM=($(free -k | grep ^Mem:))
 MEM_TOTAL=${MEM[1]}
 # For consistency across platforms, count cache as free, not used
 let MEM_USED=${MEM[1]}-${MEM[3]}-${MEM[5]}-${MEM[6]}
 let MEM_FREE=${MEM[3]}+${MEM[5]}+${MEM[6]}
-MEM_PERC=`echo "scale=2; $MEM_USED/$MEM_FREE" | bc`
+let MEM_PERC=100*$MEM_USED/$MEM_TOTAL
 
-SWAP=($(free -b | grep ^Swap:))
+SWAP=($(free -k | grep ^Swap:))
 SWAP_TOTAL=${SWAP[1]}
 SWAP_USED=${SWAP[2]}
 SWAP_FREE=${SWAP[3]}
-SWAP_PERC=`echo "scale=2; ${SWAP[2]}/${SWAP[1]}" | bc`
+let SWAP_PERC=100*${SWAP[2]}/${SWAP[1]}
 
 # pgfault is min+maj
 PG_FAULTS=$(grep ^pgfault /proc/vmstat | awk '{ print $2 }')
@@ -25,11 +25,11 @@ let PG_MINFAULTS=$PG_FAULTS-$PG_MAJFAULTS
 print_vm memory total $MEM_TOTAL
 print_vm memory used $MEM_USED
 print_vm memory free $MEM_FREE
-printf "memory\`percent_used\tn\t%0.2f\n" $MEM_PERC
+print_vm memory percent_used $MEM_PERC
 print_vm swap total $SWAP_TOTAL
 print_vm swap used $SWAP_USED
 print_vm swap free $SWAP_FREE
-printf "swap\`percent_used\tn\t%0.2f\n" $SWAP_PERC
+print_vm swap percent_used $SWAP_PERC
 print_vm info page_fault $PG_FAULTS
 print_vm info page_fault\`minor $PG_MINFAULTS
 print_vm info page_fault\`major $PG_MAJFAULTS

--- a/plugins/linux/vm.sh
+++ b/plugins/linux/vm.sh
@@ -25,11 +25,11 @@ let PG_MINFAULTS=$PG_FAULTS-$PG_MAJFAULTS
 print_vm memory total $MEM_TOTAL
 print_vm memory used $MEM_USED
 print_vm memory free $MEM_FREE
-print_vm memory percent_used $MEM_PERC
+printf "memory\`percent_used\tn\t%0.2f\n" $MEM_PERC
 print_vm swap total $SWAP_TOTAL
 print_vm swap used $SWAP_USED
 print_vm swap free $SWAP_FREE
-print_vm swap percent_used $SWAP_PERC
+printf "swap\`percent_used\tn\t%0.2f\n" $SWAP_PERC
 print_vm info page_fault $PG_FAULTS
 print_vm info page_fault\`minor $PG_MINFAULTS
 print_vm info page_fault\`major $PG_MAJFAULTS

--- a/plugins/linux/vm.sh
+++ b/plugins/linux/vm.sh
@@ -9,13 +9,13 @@ MEM_TOTAL=${MEM[1]}
 # For consistency across platforms, count cache as free, not used
 let MEM_USED=${MEM[1]}-${MEM[3]}-${MEM[5]}-${MEM[6]}
 let MEM_FREE=${MEM[3]}+${MEM[5]}+${MEM[6]}
-let MEM_PERC=100*$MEM_USED/$MEM_TOTAL
+let MEM_PERC=$MEM_USED/$MEM_TOTAL
 
 SWAP=($(free -k | grep ^Swap:))
 SWAP_TOTAL=${SWAP[1]}
 SWAP_USED=${SWAP[2]}
 SWAP_FREE=${SWAP[3]}
-let SWAP_PERC=100*${SWAP[2]}/${SWAP[1]}
+let SWAP_PERC=${SWAP[2]}/${SWAP[1]}
 
 # pgfault is min+maj
 PG_FAULTS=$(grep ^pgfault /proc/vmstat | awk '{ print $2 }')


### PR DESCRIPTION
This causes erroneous calculations.

free -k gives correct calculations and should be granular enough for most monitoring.

bc does not exist on all linux distros (such as CentOS). So forcing use of it can cause issues.
bc is also unnecessary in this situation.

MEM_PERC calculation was wrong. MEM_USED/MEM_FREE does not give the correct percentage used.