### PR TITLE
Fix non-root compile case from last change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SBIN=$(PREFIX)/sbin
 CONF=$(PREFIX)/etc/node-agent.d
 MODULES=$(PREFIX)/lib/node_modules
 RUNSTATE_DIR=$(PREFIX)/var/run/nad
+RUNSTATE_USER?=nobody
 MANIFEST_DIR=/var/svc/manifest/network/circonus
 METHOD_DIR=/var/svc/method
 MAKE?=make
@@ -19,7 +20,7 @@ install-dirs:
 	./mkinstalldirs $(DESTDIR)$(CONF)
 	./mkinstalldirs $(DESTDIR)$(MODULES)
 	./mkinstalldirs $(DESTDIR)$(RUNSTATE_DIR)
-	chown nobody $(DESTDIR)$(RUNSTATE_DIR)
+	chown $(RUNSTATE_USER) $(DESTDIR)$(RUNSTATE_DIR)
 
 install-nad:	install-dirs
 	./install-sh -c -m 0755 nad $(DESTDIR)$(SBIN)/nad


### PR DESCRIPTION
Argh, #52 broke the build if the user isn't root (which it isn't in our package builds).  This fixes that, and preserves the setting of "nobody" for the default case as documented in the readme.