### PR TITLE
updates for reverse connection stability 

### DIFF
--- a/linux-init/rhel-init
+++ b/linux-init/rhel-init
@@ -39,7 +39,7 @@ export PATH="@@PREFIX@@/embedded/bin:@@PREFIX@@/bin:/opt/omni/bin:$PATH"
 export NODE_PATH="@@PREFIX@@/lib/node_modules"
 
 run_app() {
-        runuser -p -s /bin/bash -c "nohup $NAD $NAD_OPTS >/dev/null &" nobody
+        runuser -p -s /bin/bash -c "nohup $NAD $NAD_OPTS >/dev/null 2>&1 &" nobody
 	RETVAL=$?
 	if [[ "$RETVAL" == "0" ]]; then
 		pid=$(pgrep -f $NAD)

--- a/linux-init/rhel-init
+++ b/linux-init/rhel-init
@@ -39,7 +39,7 @@ export PATH="@@PREFIX@@/embedded/bin:@@PREFIX@@/bin:/opt/omni/bin:$PATH"
 export NODE_PATH="@@PREFIX@@/lib/node_modules"
 
 run_app() {
-        runuser -p -s /bin/bash -c "nohup $NAD $NAD_OPTS >/dev/null 2>&1 &" nobody
+        runuser -p -s /bin/bash -c "nohup $NAD $NAD_OPTS >/dev/null &" nobody
 	RETVAL=$?
 	if [[ "$RETVAL" == "0" ]]; then
 		pid=$(pgrep -f $NAD)

--- a/nad
+++ b/nad
@@ -1007,8 +1007,9 @@ function setup_reverse() {
                 revs[url].reverse(m[3], '127.0.0.1', port[0][0]);
             }
             else {
-                console.error('WARN: invalid reverse connection URL,', check._reverse_connection_urls.length === 1 ? 'exiting.' : 'skipping.', url);
-                if (check._reverse_connection_urls.length === 1) {
+                var isFatal = check._reverse_connection_urls === 1;
+                console.error(isFatal ? 'ERROR:' : 'WARN:', 'invalid reverse connection URL,', isFatal ? 'exiting.' : 'skipping.', url);
+                if (isFatal) {
                     process.exit(1);
                 }
             }

--- a/nad
+++ b/nad
@@ -1007,7 +1007,7 @@ function setup_reverse() {
                 revs[url].reverse(m[3], '127.0.0.1', port[0][0]);
             }
             else {
-                var isFatal = check._reverse_connection_urls === 1;
+                var isFatal = check._reverse_connection_urls.length === 1;
                 console.error(isFatal ? 'ERROR:' : 'WARN:', 'invalid reverse connection URL,', isFatal ? 'exiting.' : 'skipping.', url);
                 if (isFatal) {
                     process.exit(1);

--- a/nad
+++ b/nad
@@ -15,7 +15,7 @@
 
 var fs = require('fs'),
     os = require('os'),
-    sys = require('sys'),
+    tls = require('tls'),
     http = require('http'),
     https = require('https'),
     url = require('url'),
@@ -122,7 +122,7 @@ function help(err) {
               "\t--apiverbose\t\tOutput API traffic to STDERR\n"
             );
   if(err) {
-    console.log("\nError: " + err + "\n");
+    console.error("Error:", err);
     process.exit(-1);
   }
 }
@@ -140,8 +140,7 @@ function index(dir) {
   // attempt to change to this directory or die trying
   try { process.chdir(dir); }
   catch (e) {
-    console.log("Cannot use configdir: " + configdir);
-    console.log(e.message);
+    console.error("Cannot use configdir:", configdir, e);
     process.exit(-1);
   }
 
@@ -334,12 +333,12 @@ if(sslport.length > 0) {
     creds.cert = fs.readFileSync(path.join(configdir, "na.crt")).toString();
     if(verify) creds.ca = fs.readFileSync(path.join(configdir, "na.ca")).toString();
   } catch(e) {
-    console.log("Make sure:");
-    console.log("\tyour key is available: " + path.join(configdir, "na.key"));
-    console.log("\tyour cert is available: " + path.join(configdir, "na.crt"));
+    console.error("Make sure:");
+    console.error("\tyour key is available: " + path.join(configdir, "na.key"));
+    console.error("\tyour cert is available: " + path.join(configdir, "na.crt"));
     if(verify)
-      console.log("\tyour ca is available: " + path.join(configdir, "na.ca"));
-    console.log("\n" + e);
+      console.error("\tyour ca is available: " + path.join(configdir, "na.ca"));
+    console.error("\n" + e);
     process.exit(-1);
   }
 }
@@ -416,7 +415,7 @@ function rescan_modules() {
     // bomb out if there's any error (we don't do any fancy
     // error handling or attempt any form of recovery)
     if (err) {
-      console.log("Can't read config dir '"+configdir+"': "+err);
+      console.error("Can't read config dir '"+configdir+"':", err);
       process.exit(-1);
     }
 
@@ -851,7 +850,7 @@ if ( ! api_setup ) {
       for(var i=0; i<port.length; i++)
         http.createServer(handler).listen(port[i][0] , port[i][1]);
     } catch(e) {
-      console.log("Failed to start server on port " + port + ": " + e);
+      console.error("Failed to start server on port", port, e);
       process.exit(-1);
     }
 
@@ -860,7 +859,7 @@ if ( ! api_setup ) {
       for(var i=0; i<sslport.length; i++)
         https.createServer(creds, handler).listen(sslport[i][0], sslport[i][1]);
     } catch(e) {
-      console.log("Failed to start server on port " + sslport + ": " + e);
+      console.error("Failed to start server on port", sslport, e);
       process.exit(-1);
     }
 }
@@ -876,6 +875,15 @@ if ( ! api_setup ) {
 // style HTTP GET requests and be handled in the normal "handler" function.
 var revs = {}
 
+var revSetupAttempts = 0;
+var maxRevSetupAttempts = 5;
+
+function getRetryInterval() {
+    var minRetryInterval = 5 * 1000; // 5 seconds
+    var maxRetryInterval = 30 * 1000; // 30 seconds
+    return Math.floor(Math.random() * (maxRetryInterval - minRetryInterval + 1)) + minRetryInterval;
+}
+
 function setup_reverse() {
     var noit;
 
@@ -883,69 +891,121 @@ function setup_reverse() {
         noit = require('noit-connection');
     }
     catch (e) {
-        console.error("Failed to load noit-connection module");
-        return;
+        console.error('ERROR: Failed to load noit-connection module -', e);
+        // explicit request to use reverse connections but, unable to establish the connection
+        // exit intentionally so there is a record in logging and service management can handle
+        // a persistently failing service in its usual manner.
+        process.exit(1);
     }
+
+    var getNoitCreds = function getNoitCreds() {
+        var noitCreds = null;
+        var credFunc = null;
+
+        if (cafile) {
+            noitCreds = noit.hashToCreds({ca: cafile});
+        }
+        else {
+            // crypto.createCredentials is deprecated in v4+
+            if (typeof tls.createSecureContext === 'function') {
+                credFunc = tls.createSecureContext;
+            }
+            else if (typeof crypto.createCredentials === 'function') {
+                credFunc = crypto.createCredentials;
+            }
+
+            if (credFunc === null) {
+                console.error('ERROR: Unable to determine correct method to create secure context for reverse connection.');
+                process.exit(1);
+            }
+
+            noitCreds = credFunc({ ca: [
+                '-----BEGIN CERTIFICATE-----',
+                'MIID4zCCA0ygAwIBAgIJAMelf8skwVWPMA0GCSqGSIb3DQEBBQUAMIGoMQswCQYD',
+                'VQQGEwJVUzERMA8GA1UECBMITWFyeWxhbmQxETAPBgNVBAcTCENvbHVtYmlhMRcw',
+                'FQYDVQQKEw5DaXJjb251cywgSW5jLjERMA8GA1UECxMIQ2lyY29udXMxJzAlBgNV',
+                'BAMTHkNpcmNvbnVzIENlcnRpZmljYXRlIEF1dGhvcml0eTEeMBwGCSqGSIb3DQEJ',
+                'ARYPY2FAY2lyY29udXMubmV0MB4XDTA5MTIyMzE5MTcwNloXDTE5MTIyMTE5MTcw',
+                'NlowgagxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMI',
+                'Q29sdW1iaWExFzAVBgNVBAoTDkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJj',
+                'b251czEnMCUGA1UEAxMeQ2lyY29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4w',
+                'HAYJKoZIhvcNAQkBFg9jYUBjaXJjb251cy5uZXQwgZ8wDQYJKoZIhvcNAQEBBQAD',
+                'gY0AMIGJAoGBAKz2X0/0vJJ4ad1roehFyxUXHdkjJA9msEKwT2ojummdUB3kK5z6',
+                'PDzDL9/c65eFYWqrQWVWZSLQK1D+v9xJThCe93v6QkSJa7GZkCq9dxClXVtBmZH3',
+                'hNIZZKVC6JMA9dpRjBmlFgNuIdN7q5aJsv8VZHH+QrAyr9aQmhDJAmk1AgMBAAGj',
+                'ggERMIIBDTAdBgNVHQ4EFgQUyNTsgZHSkhhDJ5i+6IFlPzKYxsUwgd0GA1UdIwSB',
+                '1TCB0oAUyNTsgZHSkhhDJ5i+6IFlPzKYxsWhga6kgaswgagxCzAJBgNVBAYTAlVT',
+                'MREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMIQ29sdW1iaWExFzAVBgNVBAoT',
+                'DkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJjb251czEnMCUGA1UEAxMeQ2ly',
+                'Y29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4wHAYJKoZIhvcNAQkBFg9jYUBj',
+                'aXJjb251cy5uZXSCCQDHpX/LJMFVjzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB',
+                'BQUAA4GBAAHBtl15BwbSyq0dMEBpEdQYhHianU/rvOMe57digBmox7ZkPEbB/baE',
+                'sYJysziA2raOtRxVRtcxuZSMij2RiJDsLxzIp1H60Xhr8lmf7qF6Y+sZl7V36KZb',
+                'n2ezaOoRtsQl9dhqEMe8zgL76p9YZ5E69Al0mgiifTteyNjjMuIW',
+                '-----END CERTIFICATE-----'
+            ].join('\n')});
+        }
+
+        creds.rejectUnauthorized = false;
+
+        return noitCreds;
+    };
 
     var circapi_cb = function(code, err, data) {
         if (err) {
-            console.error("reverse connection callback:", code, err, data);
+            revSetupAttempts++;
+            var retryInterval = getRetryInterval();
+            console.error('WARN: reverse connection -', code, err, data,
+                'trying again in', Math.round(retryInterval / 1000)+'s. Attempt',
+                revSetupAttempts, 'of', maxRevSetupAttempts);
+            if (revSetupAttempts >= maxRevSetupAttempts) {
+                console.error('ERROR: Failed to setup reverse connection after', maxRevSetupAttempts, 'attempts.');
+                // explicit request to use reverse connections but, unable to establish the connection
+                // exit intentionally so there is a record in logging and service management can handle
+                // a persistently failing service in its usual manner.
+                process.exit(1);
+            }
+            setTimeout(setup_reverse, retryInterval);
+            return;
         }
 
-        if (typeof(data) == 'object') {
-            var check = {};
-
-            if (data.length >= 1) {
-                check = data[0];
-            } else {
-                check = data;
-            }
-
-            if (check._reverse_connection_urls && check._reverse_connection_urls.length > 0) {
-                check._reverse_connection_urls.forEach(function(url) {
-                    var m = /^mtev_reverse:\/\/(.+):(\d+)\/([^.]+)$/.exec(url);
-
-                    if (m) {
-                        var creds = crypto.createCredentials({
-                            ca: "-----BEGIN CERTIFICATE-----\n" +
-                            "MIID4zCCA0ygAwIBAgIJAMelf8skwVWPMA0GCSqGSIb3DQEBBQUAMIGoMQswCQYD\n" +
-                            "VQQGEwJVUzERMA8GA1UECBMITWFyeWxhbmQxETAPBgNVBAcTCENvbHVtYmlhMRcw\n" +
-                            "FQYDVQQKEw5DaXJjb251cywgSW5jLjERMA8GA1UECxMIQ2lyY29udXMxJzAlBgNV\n" +
-                            "BAMTHkNpcmNvbnVzIENlcnRpZmljYXRlIEF1dGhvcml0eTEeMBwGCSqGSIb3DQEJ\n" +
-                            "ARYPY2FAY2lyY29udXMubmV0MB4XDTA5MTIyMzE5MTcwNloXDTE5MTIyMTE5MTcw\n" +
-                            "NlowgagxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMI\n" +
-                            "Q29sdW1iaWExFzAVBgNVBAoTDkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJj\n" +
-                            "b251czEnMCUGA1UEAxMeQ2lyY29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4w\n" +
-                            "HAYJKoZIhvcNAQkBFg9jYUBjaXJjb251cy5uZXQwgZ8wDQYJKoZIhvcNAQEBBQAD\n" +
-                            "gY0AMIGJAoGBAKz2X0/0vJJ4ad1roehFyxUXHdkjJA9msEKwT2ojummdUB3kK5z6\n" +
-                            "PDzDL9/c65eFYWqrQWVWZSLQK1D+v9xJThCe93v6QkSJa7GZkCq9dxClXVtBmZH3\n" +
-                            "hNIZZKVC6JMA9dpRjBmlFgNuIdN7q5aJsv8VZHH+QrAyr9aQmhDJAmk1AgMBAAGj\n" +
-                            "ggERMIIBDTAdBgNVHQ4EFgQUyNTsgZHSkhhDJ5i+6IFlPzKYxsUwgd0GA1UdIwSB\n" +
-                            "1TCB0oAUyNTsgZHSkhhDJ5i+6IFlPzKYxsWhga6kgaswgagxCzAJBgNVBAYTAlVT\n" +
-                            "MREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMIQ29sdW1iaWExFzAVBgNVBAoT\n" +
-                            "DkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJjb251czEnMCUGA1UEAxMeQ2ly\n" +
-                            "Y29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4wHAYJKoZIhvcNAQkBFg9jYUBj\n" +
-                            "aXJjb251cy5uZXSCCQDHpX/LJMFVjzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB\n" +
-                            "BQUAA4GBAAHBtl15BwbSyq0dMEBpEdQYhHianU/rvOMe57digBmox7ZkPEbB/baE\n" +
-                            "sYJysziA2raOtRxVRtcxuZSMij2RiJDsLxzIp1H60Xhr8lmf7qF6Y+sZl7V36KZb\n" +
-                            "n2ezaOoRtsQl9dhqEMe8zgL76p9YZ5E69Al0mgiifTteyNjjMuIW\n" +
-                            "-----END CERTIFICATE-----" }
-                        );
-
-                        creds.rejectUnauthorized = false;
-
-                        revs[url] = new noit.connection(m[2], m[1],
-                            cafile ? noit.utils.hashToCreds({ ca:cafile }) : creds);
-                        revs[url].reverse(m[3], "127.0.0.1", port[0][0]);
-                    }
-                });
+        if (data === null || typeof data !== 'object') {
+            if (check_bundle_id == null) {
+                console.error('ERROR: configuration for reverse - searching yielded no applicable json:nad check for', hostname);
             }
             else {
-                console.log("configuration error for reverse: no URLs found");
+                console.error('ERROR: configuration for reverse - unable to retrieve check', check_bundle_id, 'object with API.');
             }
+            // explicit request to use reverse connections but, incorrect configuration prevents
+            // correct functionality. exit intentionally so there is a record in logging and
+            // service management can handle a persistently failing service in its usual manner.
+            process.exit(1);
+        }
+
+        var check = {};
+
+        if (Array.isArray(data) && data.length >= 1) {
+            check = data[0];
+        } else {
+            check = data;
+        }
+
+        if (check._reverse_connection_urls && check._reverse_connection_urls.length > 0) {
+            check._reverse_connection_urls.forEach(function(url) {
+                var m = /^mtev_reverse:\/\/(.+):(\d+)\/([^.]+)$/.exec(url);
+
+                if (m) {
+                    revs[url] = new noit.connection(m[2], m[1], getNoitCreds());
+                    revs[url].reverse(m[3], '127.0.0.1', port[0][0]);
+                }
+            });
         }
         else {
-            console.log("configuration error for reverse: no applicable check found");
+            console.error('ERROR: configuration for reverse - no reverse URLs found in', check._cid);
+            // explicit request to use reverse connections but, incorrect configuration prevents
+            // correct functionality. exit intentionally so there is a record in logging and
+            // service management can handle a persistently failing service in its usual manner.
+            process.exit(1);
         }
     };
 

--- a/nad
+++ b/nad
@@ -969,7 +969,7 @@ function setup_reverse() {
             return;
         }
 
-        if (data === null || typeof data !== 'object') {
+        if (data === null || typeof data !== 'object' || (Array.isArray(data) && data.length === 0)) {
             if (check_bundle_id == null) {
                 console.error('ERROR: configuration for reverse - searching yielded no applicable json:nad check for', hostname);
             }
@@ -984,7 +984,7 @@ function setup_reverse() {
 
         var check = {};
 
-        if (Array.isArray(data) && data.length >= 1) {
+        if (Array.isArray(data)) {
             check = data[0];
         } else {
             check = data;

--- a/nad
+++ b/nad
@@ -913,8 +913,7 @@ function setup_reverse() {
             else if (typeof crypto.createCredentials === 'function') {
                 credFunc = crypto.createCredentials;
             }
-
-            if (credFunc === null) {
+            else {
                 console.error('ERROR: Unable to determine correct method to create secure context for reverse connection.');
                 process.exit(1);
             }
@@ -970,7 +969,7 @@ function setup_reverse() {
         }
 
         if (data === null || typeof data !== 'object' || (Array.isArray(data) && data.length === 0)) {
-            if (check_bundle_id == null) {
+            if (check_bundle_id === null) {
                 console.error('ERROR: configuration for reverse - searching yielded no applicable json:nad check for', hostname);
             }
             else {
@@ -990,28 +989,35 @@ function setup_reverse() {
             check = data;
         }
 
-        if (check._reverse_connection_urls && check._reverse_connection_urls.length > 0) {
-            check._reverse_connection_urls.forEach(function(url) {
-                var m = /^mtev_reverse:\/\/(.+):(\d+)\/([^.]+)$/.exec(url);
-
-                if (m) {
-                    revs[url] = new noit.connection(m[2], m[1], getNoitCreds());
-                    revs[url].reverse(m[3], '127.0.0.1', port[0][0]);
-                }
-            });
-        }
-        else {
-            console.error('ERROR: configuration for reverse - no reverse URLs found in', check._cid);
-            // explicit request to use reverse connections but, incorrect configuration prevents
-            // correct functionality. exit intentionally so there is a record in logging and
-            // service management can handle a persistently failing service in its usual manner.
+        if (!check.hasOwnProperty('_reverse_connection_urls')) {
+            console.error('ERROR: invalid check, does not contain a reverse connection URL.', check._cid);
             process.exit(1);
         }
+
+        if (!Array.isArray(check._reverse_connection_urls) || check._reverse_connection_urls.length === 0) {
+            console.error('ERROR: invalid check, reverse connection URL attribute is invalid.', check._cid);
+            process.exit(1);
+        }
+
+        check._reverse_connection_urls.forEach(function(url) {
+            var m = /^mtev_reverse:\/\/(.+):(\d+)\/([^.]+)$/.exec(url);
+
+            if (m) {
+                revs[url] = new noit.connection(m[2], m[1], getNoitCreds());
+                revs[url].reverse(m[3], '127.0.0.1', port[0][0]);
+            }
+            else {
+                console.error('WARN: invalid reverse connection URL,', check._reverse_connection_urls.length === 1 ? 'exiting.' : 'skipping.', url);
+                if (check._reverse_connection_urls.length === 1) {
+                    process.exit(1);
+                }
+            }
+        });
     };
 
     circapi.setup(auth_token, 'nad', api_options);
 
-    if (check_bundle_id == null) {
+    if (check_bundle_id === null) {
         circapi.get('/check_bundle?f_type=json:nad&f_target=' + hostname, null, circapi_cb);
     }
     else {

--- a/node_modules/noit-connection/noit-connection.js
+++ b/node_modules/noit-connection/noit-connection.js
@@ -556,7 +556,7 @@ nc.prototype.reverse = function(name, host, port) {
             }
             catch(e) {
                 console.error(lotTS(), "handling incoming packet from", parent.host, e, e.stack);
-                parent.stop();
+                parent.socket.end();
             }
         });
     });

--- a/node_modules/noit-connection/noit-connection.js
+++ b/node_modules/noit-connection/noit-connection.js
@@ -29,160 +29,364 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-var sys = require('util'),
-    fs = require('fs'),
-    net = require('net'),
-    util = require('util'),
-    https = require('https'),
-    crypto = require('crypto'),
-    tls = require('tls'),
-    EventEmitter = require('events').EventEmitter,
-    stats = {},
-    debug = global.debug;
+var crypto = require('crypto');
+var EventEmitter = require('events').EventEmitter;
+var fs = require('fs');
+var https = require('https');
+var net = require('net');
+var tls = require('tls');
+var util = require('util');
 
-var MAX_FRAME_LEN = 65530,
-    CMD_BUFF_LEN = 4096;
+var debug = global.debug || 0;
+var stats = {};
 
-var nc = function(port,host,creds,cn) {
-  this.shutdown = false;
-  this.port = port;
-  this.host = host;
-  this.remote = host + ":" + port;
-  this.stats = stats;
-  if(! (this.remote in this.stats)) this.stats[this.remote] = {
-    connects: 0, connections: 0, closes: 0
-  };
-  this.options = creds;
-  this.options.host = host;
-  this.options.port = port;
-  if(!this.options.hasOwnProperty('rejectUnauthorized')) {
-    this.options.rejectUnauthorized = false;
-  }
-  if(cn) {
-    this.cn = cn;
-    this.options.servername = cn;
-  }
-  this.channels = {};
+// maximum amount of time (ms) between communications
+// e.g. if interval between the last rx or tx and "now"
+// is >MAX_COMM_INTERVAL, reset the reverse connection.
+// this is a brute force timer, when communications get
+// wedged and the socket timeout does not fire (for whatever
+// reason, exact circumstances are not easy to replicate.).
+var MAX_COMM_INTERVAL = 300 * 1000; // maximum amount of time between communications
+var SOCKET_TIMEOUT = 90 * 1000;     // if no communications in this time, reset reverse
+var WATCHDOG_ENABLED = true;
+var WATCHDOG_INTERVAL = 60 * 1000;  // frequency of enforcing MAX_COMM_INTERVAL
+
+var CMD_BUFF_LEN = 4096;
+var MAX_FRAME_LEN = 65530;
+
+function logTS() {
+    return debug > 0 ? (new Date()).toISOString() : '';
+}
+
+function getRetryInterval() {
+    var minRetryInterval = 5 * 1000; // 5 seconds
+    var maxRetryInterval = 30 * 1000; // 30 seconds
+    return Math.floor(Math.random() * (maxRetryInterval - minRetryInterval + 1)) + minRetryInterval;
+}
+
+var nc = function(port, host, creds, cn) {
+    this.shutdown = false;
+    this.port = port;
+    this.host = host;
+    this.remote = host + ":" + port;
+    this.stats = stats;
+
+    if (!(this.remote in this.stats)) {
+        this.stats[this.remote] = {
+            connects: 0, connections: 0, closes: 0
+        };
+    }
+
+    this.options = creds;
+    this.options.host = host;
+    this.options.port = port;
+
+    if (!this.options.hasOwnProperty('rejectUnauthorized')) {
+        this.options.rejectUnauthorized = false;
+    }
+
+    if (cn) {
+        this.cn = cn;
+        this.options.servername = cn;
+    }
+
+    this.channels = {};
+
+    this.commTracker = {
+        lastRx: 0,
+        lastTx: 0
+    };
+    this.watchdog = null;
+    this.buflist = [];
+    this.watchdogEnabled = WATCHDOG_ENABLED;
 };
 
-sys.inherits(nc, EventEmitter);
+util.inherits(nc, EventEmitter);
+
+nc.prototype.setDebug = function setDebug(debugLevel) {
+    debug = debugLevel;
+};
+
+nc.prototype.commWatchdog = function commWatchdog(parent) {
+    if (debug >= 4) {
+        var dte = new Date();
+        console.log("\n====================", "watchdog", "start");
+        console.log(dte.toISOString());
+    }
+
+    if (parent.watchdog !== null) {
+        if (debug >= 5) {
+            console.log("clearing watchdog (inside watchdog)");
+        }
+        clearTimeout(parent.watchdog);
+        parent.watchdog = null;
+    }
+
+    var stateOk = true;
+
+    if (parent.commTracker.lastRx > 0 && parent.commTracker.lastTx > 0) {
+        var ts = Date.now();
+        var rxInterval = ts - parent.commTracker.lastRx;
+        var txInterval = ts - parent.commTracker.lastTx;
+        stateOk = rxInterval < MAX_COMM_INTERVAL && txInterval < MAX_COMM_INTERVAL
+        if (debug >= 4) {
+            console.log("last rx", rxInterval > 1000 ? Math.round(rxInterval / 1000) + "s" : rxInterval + "ms", "ago.");
+            console.log("last tx", txInterval > 1000 ? Math.round(txInterval / 1000) + "s" : txInterval + "ms", "ago.");
+            if (debug >= 5) {
+                console.log("rx/tx interval ok?", stateOk);
+            }
+        }
+    }
+
+    if (stateOk) {
+        if (debug >= 5) {
+            console.log("setting watchdog (inside watchdog)");
+        }
+        parent.watchdog = setTimeout(parent.commWatchdog, WATCHDOG_INTERVAL, parent);
+    }
+    else {
+        console.error("!!!WATCHDOG!!! resetting NAD reverse connection due to excessive interval since last communication with", parent.host);
+        if (debug >= 4) {
+            console.error("rx", rxInterval, MAX_COMM_INTERVAL, rxInterval < MAX_COMM_INTERVAL);
+            console.error("tx", txInterval, MAX_COMM_INTERVAL, txInterval < MAX_COMM_INTERVAL);
+        }
+        if (parent.socket) {
+            parent.socket.end();
+        }
+    }
+    if (debug >= 4) {
+        console.log("====================", "watchdog", "end\n");
+    }
+}
+
+nc.prototype.toggleWatchdog = function toggleWatchdog() {
+    if (this.watchdogEnabled) {
+        this.watchdogEnabled = false;
+        if (this.watchdog !== null) {
+            clearTimeout(this.watchdog);
+        }
+    } else {
+        this.watchdogEnabled = true;
+        this.commWatchdog(this);
+    }
+}
 
 nc.prototype.stop = function() {
-  this.shutdown = true;
-  if(this.socket) {
-    this.socket.end();
-    this.socket.destroy();
-  }
-  this.socket = null;
+    if (debug >= 2) {
+        console.log(logTS(), "Stopping reverse connection to", this.host);
+    }
+
+    if (this.channels) {
+        for (var channel_id in this.channels) {
+            var channel = this.channels[channel_id];
+            if (channel.socket) {
+                channel.socket.end();
+                channel.socket.destroy();
+            }
+        }
+    }
+
+    if (this.socket) {
+        this.socket.end();
+        this.socket.destroy();
+    }
+
+    this.buflist = [];
+    this.channels = {};
+    this.socket = null;
+    this.commTracker = {
+        lastRx: 0,
+        lastTx: 0
+    };
+    this.shutdown = true;
+    this.watchdog = null;
 }
 
 nc.prototype.start = function(conncb) {
-  var parent = this;
-  this.conncb = conncb;
-  parent.stats.global.connects++;
-  parent.stats[parent.remote].connects++;
-  parent.stats.global.connections++;
-  parent.stats[parent.remote].connections++;
-  parent.socket = tls.connect(this.options,
-    function() {
-      if(parent.socket.authorized == false &&
-         parent.socket.authorizationError != 'SELF_SIGNED_CERT_IN_CHAIN') {
-        console.log('invalid cert: ' + parent.socket.authorizationError);
-        throw('invalid cert: ' + parent.socket.authorizationError);
-      }
-      parent.remote_cert = parent.socket.getPeerCertificate();
-      if(parent.cn && parent.remote_cert.subject.CN != parent.cn) {
-        throw('invalid cert: CN mismatch');
-      }
-      parent.socket.authorized = true;
-      parent.conncb(parent);
+    var parent = this;
+
+    if (debug >= 2) {
+        console.log(logTS(), "Starting reverse connection to", this.host);
     }
-  );
-  this.socket.addListener('error', function(e) {
-    console.log('noit ('+parent.host+'): '+e);
-    parent.reverse_cleanup();
-    setTimeout(function() { parent.start(parent.conncb); }, 1000);
-  });
-  this.socket.addListener('close',
-    function() {
-      parent.stats.global.closes++;
-      parent.stats[parent.remote].closes++;
-      parent.stats.global.connections--;
-      parent.stats[parent.remote].connections--;
-      if(!parent.socket) console.log('socket closed');
-      else if (parent.socket.authorized == false) console.log('invalid cert ('+parent.host+')');
-      parent.reverse_cleanup();
-      if(!parent.shutdown) {
-        if(parent.socket) parent.socket.destroy();
-        parent.socket = null;
-        setTimeout(function() { parent.start(parent.conncb); }, 1000);
-      }
+
+    if (this.watchdog !== null) {
+        if (debug >= 5) {
+            console.log(logTS(), "Clearing watchdog (inside start)");
+        }
+        clearTimeout(this.watchdog);
+        this.watchdog = null;
     }
-  );
+
+    this.conncb = conncb;
+    this.stats.global.connects++;
+    this.stats[this.remote].connects++;
+    this.stats.global.connections++;
+    this.stats[this.remote].connections++;
+
+    this.socket = tls.connect(this.options, function() {
+        if (parent.socket.authorized == false &&
+            parent.socket.authorizationError != 'SELF_SIGNED_CERT_IN_CHAIN') {
+                var err = new Error(util.format("Invalid cert: %s", parent.socket.authorizationError));
+                return parent.conncb(err, parent);
+        }
+        parent.remote_cert = parent.socket.getPeerCertificate();
+        if (parent.cn && parent.remote_cert.subject.CN != parent.cn) {
+            var err = new Error(util.format("Invalid cert: CN mismatch %s != %s", parent.cn, parent.remote_cert.subject.CN));
+            return parent.conncb(err, parent);
+        }
+        parent.socket.authorized = true;
+        parent.conncb(null, parent);
+        console.error(logTS(), "Established reverse connection to remote", parent.host);
+        if (parent.watchdogEnabled && parent.watchdog === null) {
+            if (debug >= 5) {
+                console.log(logTS(), "Setting watchdog (inside start connect cb)");
+            }
+            parent.watchdog = setTimeout(parent.commWatchdog, WATCHDOG_INTERVAL, parent);
+        }
+    });
+
+    this.socket.addListener('error', function(e) {
+        console.error(logTS(), "Remote", parent.host, e);
+        if (parent.socket) {
+            if (debug >= 5) {
+                console.log(logTS(), "Socket end to trigger close");
+            }
+            parent.socket.end(); // trigger close event
+        }
+        else {
+            if (debug >= 5) {
+                console.log(logTS(), "Parent stop and re-call start (no parent.socket)");
+            }
+            parent.stop();      // force cleanup
+            setTimeout(function() { parent.start(parent.conncb); }, getRetryInterval());
+        }
+    });
+
+    // enforce a timeout, normally there is no tiemout on sockets.
+    this.socket.setTimeout(SOCKET_TIMEOUT);
+    this.socket.addListener('timeout', function() {
+        console.error(logTS(), "Remote", parent.host, "timeout(event)",
+            "last RX:", parent.commTracker.lastRx ? (new Date(parent.commTracker.lastRx)).toISOString() : "unknown",
+            "last TX:", parent.commTracker.lastTx ? (new Date(parent.commTracker.lastTx)).toISOString() : "unknown");
+        if (parent.socket) {
+            if (debug >= 5) {
+                console.log(logTS(), "Socket end to trigger close");
+            }
+            parent.socket.end(); // trigger close event
+        }
+        else {
+            if (debug >= 5) {
+                console.log(logTS(), "Parent stop and re-call start (no parent.socket)");
+            }
+            parent.stop();      // force cleanup
+            setTimeout(function() { parent.start(parent.conncb); }, getRetryInterval());
+        }
+    });
+
+    this.socket.addListener('close', function() {
+        console.error(logTS(), "Remote", parent.host, "close(event)");
+        if (parent.watchdog !== null) {
+            if (debug >= 5) {
+                console.log(logTS(), "Clearing watchdog (inside start:close(event))");
+            }
+            clearTimeout(parent.watchdog);
+            parent.watchdog = null;
+        }
+        parent.stats.global.closes++;
+        parent.stats[parent.remote].closes++;
+        parent.stats.global.connections--;
+        parent.stats[parent.remote].connections--;
+        if (!parent.socket) {
+            console.log(lotTS(), 'socket is already closed');
+        }
+        else if (parent.socket.authorized == false) {
+            console.log(logTS(), "Invalid cert for", parent.host);
+        }
+        parent.stop();
+        var retryInterval = getRetryInterval();
+        console.error(logTS(), "Attempting to re-establish reverse connection in", Math.round(retryInterval / 1000)+"s.");
+        setTimeout(function() { parent.start(parent.conncb); }, retryInterval);
+    });
 };
 
 
 function decode_frame(blist) {
-  var frame = {}
-  var hdr = new Buffer(6); /* hdr uint16 + uint32 */
-  var i, avail = 0, needed = 0, read_header = false;
-  for(i=0;i<blist.length;i++) {
-    needed = Math.min(blist[i].length, hdr.length - avail);
-    blist[i].copy(hdr, avail, 0, needed);
-    avail += needed;
-    if(avail >= hdr.length) { /* header size */
-      frame.channel_id = hdr.readUInt16BE(0);
-      frame.command = (frame.channel_id & 0x8000) ? true: false;
-      frame.channel_id &= 0x7fff;
-      frame.bufflen = hdr.readUInt32BE(2);
-      if(frame.bufflen > MAX_FRAME_LEN) {
-        throw('oversized_frame: ' + frame.bufflen);
-      }
-      frame.buff = new Buffer(frame.bufflen);
-      read_header = true;
-      break;
+    var frame = {};
+    var hdr = new Buffer(6); /* hdr uint16 + uint32 */
+    var i, avail = 0, needed = 0, read_header = false;
+
+    for (i = 0; i < blist.length; i++) {
+        needed = Math.min(blist[i].length, hdr.length - avail);
+        blist[i].copy(hdr, avail, 0, needed);
+        avail += needed;
+        if (avail >= hdr.length) { /* header size */
+            frame.channel_id = hdr.readUInt16BE(0);
+            frame.command = (frame.channel_id & 0x8000) ? true: false;
+            frame.channel_id &= 0x7fff;
+            frame.bufflen = hdr.readUInt32BE(2);
+            if (frame.bufflen > MAX_FRAME_LEN) {
+                throw('oversized_frame: ' + frame.bufflen); // try/catch wrap in caller, not a callback
+            }
+            frame.buff = new Buffer(frame.bufflen);
+            read_header = true;
+            break;
+        }
     }
-  }
-  if(!read_header) return null;
-  if(needed == blist[i].length) { /* we used the whole buffer */
-    i++;
-    needed = 0;
-  }
-  var start = needed;
-  avail = 0;
-  for(;i<blist.length;i++) {
-    needed = Math.min(blist[i].length-start, frame.buff.length - avail);
-    blist[i].copy(frame.buff, avail, start, (start+needed));
-    avail += needed;
-    if(avail == frame.buff.length) {
-      /* we are complete... adjust out blist in place and return frame */
-      if((start+needed) == blist[i].length) { i++; start = needed = 0; }
-      if(i > 0) {
-        blist.splice(0, i);
-      }
-      if((start+needed) != 0) {
-        blist[0] = blist[0].slice((start+needed));
-      }
-      return frame;
+
+    if (!read_header) {
+         return null;
     }
-    start = 0;
-  }
-  return null;
+
+    if (needed == blist[i].length) { /* we used the whole buffer */
+        i++;
+        needed = 0;
+    }
+
+    var start = needed;
+
+    avail = 0;
+    for( ; i < blist.length; i++) {
+        needed = Math.min(blist[i].length-start, frame.buff.length - avail);
+        blist[i].copy(frame.buff, avail, start, (start+needed));
+        avail += needed;
+        if (avail == frame.buff.length) {
+            /* we are complete... adjust out blist in place and return frame */
+            if ((start+needed) == blist[i].length) {
+                i++;
+                start = needed = 0;
+            }
+
+            if (i > 0) {
+                blist.splice(0, i);
+            }
+
+            if ((start+needed) != 0) {
+                blist[0] = blist[0].slice((start+needed));
+            }
+
+            return frame;
+        }
+        start = 0;
+    }
+    return null;
 }
 
-nc.prototype.reverse_cleanup = function(conncb) {
-  var parent = this;
-  parent.buflist = [];
-  if(parent.channels) {
-    for(var channel_id in parent.channels) {
-      var channel = parent.channels[channel_id];
-      if(channel.socket) {
-        channel.socket.end();
-        channel.socket.destroy();
-      }
+nc.prototype.reverse_cleanup = function() {
+    this.buflist = [];
+    if (this.channels) {
+        for (var channel_id in this.channels) {
+            var channel = this.channels[channel_id];
+            if (channel.socket) {
+                channel.socket.end();
+                channel.socket.destroy();
+            }
+        }
+        this.channels = {};
     }
-    parent.channels = {};
-  }
+    this.commTracker = {
+        lastRx: 0,
+        lastTx: 0
+    };
 }
 
 var CMD_CONNECT = new Buffer('CONNECT', 'utf8'),
@@ -191,118 +395,190 @@ var CMD_CONNECT = new Buffer('CONNECT', 'utf8'),
     CMD_RESET = new Buffer('RESET', 'utf8');
 
 function frame_output(channel_id, command, buff) {
-  var frame = new Buffer(6 + buff.length);
-  buff.copy(frame, 6, 0, buff.length);
-  frame.writeUInt16BE((channel_id & 0x7fff) | (command ? 0x8000 : 0), 0);
-  frame.writeUInt32BE(buff.length, 2);
-  if(debug >= 3) console.log('send', channel_id, command ? "comm" : "data", buff.length, frame.slice(0,6));
-  return frame;
+    var frame = new Buffer(6 + buff.length);
+
+    buff.copy(frame, 6, 0, buff.length);
+    frame.writeUInt16BE((channel_id & 0x7fff) | (command ? 0x8000 : 0), 0);
+    frame.writeUInt32BE(buff.length, 2);
+    if (debug >= 4) {
+        console.log(logTS(), 'Prepared', command ? "'comm'" : "'data'", "for channel", channel_id,
+            "- buffer length", buff.length, frame.slice(0,6).toJSON());
+    }
+    return frame;
 }
 
 function isCmd(buf1, buf2) {
-  if(buf1.length != buf2.length) return false;
-  for(var i=0;i<buf1.length;i++) {
-    if(buf1[i] != buf2[i]) return false;
-  }
-  return true;
+    if (buf1.length != buf2.length) {
+        return false;
+    }
+    for (var i = 0; i < buf1.length; i++) {
+        if (buf1[i] != buf2[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 function handle_frame(parent, frame, host, port) {
-  if(!parent.channels[frame.channel_id])
-    parent.channels[frame.channel_id] = { id: frame.channel_id };
-  var chan = parent.channels[frame.channel_id];
-  if(frame.command) {
-    if(isCmd(frame.buff, CMD_CONNECT)) {
-      if(chan.socket) {
-        chan.socket.end();
-        chan.socket.destroy();
-        chan.socket = null;
-        chan = parent.channels[frame.channel_id] = { id: chan.id };
-        parent.socket.write(frame_output(chan.id, true, CMD_RESET));
-      }
-      chan.socket = net.connect( { host: host, port: port } );
-      if(debug >= 2) console.log('connecting to ', host, ':', port, 'on channel', chan.id);
-      chan.socket.on('error', (function(parent, chan) {
-        return function(err) {
-          if(debug >= 3) console.log('close to remote on channel', chan.id, err);
-          parent.socket.write(frame_output(chan.id, true, CMD_RESET));
-        }
-      })(parent,chan));
-      chan.socket.on('connect', (function(parent, chan) {
-        return function() {
-          if(debug >= 3) console.log('connect on channel', chan.id);
-          if(chan.socket) {
-            chan.socket.on('data', function(buff) {
-              if(debug >= 3) console.log('data to remote on channel', chan.id);
-              parent.socket.write(frame_output(chan.id, false, buff));
-            });
-            chan.socket.on('end', function(buff) {
-              if(debug >= 3) console.log('close to remote on channel', chan.id);
-              parent.socket.write(frame_output(chan.id, true, CMD_CLOSE));
-            });
-          }
-        }})(parent,chan));
+    if (!parent.channels[frame.channel_id]) {
+        parent.channels[frame.channel_id] = { id: frame.channel_id };
     }
-    else if(isCmd(frame.buff, CMD_CLOSE) ||
+
+    var chan = parent.channels[frame.channel_id];
+
+    if (frame.command) {
+        if (isCmd(frame.buff, CMD_CONNECT)) {
+            if (chan.socket) {
+                chan.socket.end();
+                chan.socket.destroy();
+                chan.socket = null;
+                chan = parent.channels[frame.channel_id] = { id: chan.id };
+                parent.socket.write(frame_output(chan.id, true, CMD_RESET));
+            }
+
+            if (debug >= 2) {
+                console.log(logTS(), "Connecting to", host, "on port", port, "channel", chan.id);
+            }
+            chan.socket = net.connect( { host: host, port: port } );
+
+            chan.socket.on('connect', (function(parent, chan) {
+                return function() {
+                    if (debug >= 3) {
+                        console.log(logTS(), "Connected to", host, "on port", port, "channel", chan.id);
+                    }
+                    if (chan.socket) {
+                        chan.socket.on('data', function(buff) {
+                            if (debug >= 3) {
+                                console.log(logTS(), "Sending 'data' from local to", parent.host, "for channel", chan.id);
+                            }
+                            parent.socket.write(frame_output(chan.id, false, buff));
+                            parent.commTracker.lastTx = Date.now(); // update lastTx AFTER successful socket.write
+                            if (debug >= 3) {
+                                console.log(logTS(), "Sent 'data' from local to", parent.host, "for channel", chan.id);
+                            }
+                        });
+
+                        chan.socket.on('end', function(buff) {
+                            if (debug >= 3) {
+                                console.log(logTS(), "Sending close command to", parent.host, "for channel", chan.id);
+                            }
+                            parent.socket.write(frame_output(chan.id, true, CMD_CLOSE));
+                            parent.commTracker.lastTx = Date.now(); // update lastTx AFTER successful socket.write
+                            if (debug >= 3) {
+                                console.log(logTS(), "Sent close command to", parent.host, "for channel", chan.id);
+                            }
+                        });
+                    }
+                    else {
+                        console.error(logTS(), "warn: connect event on chan.socket but no chan.socket...");
+                    }
+                };
+            })(parent, chan));
+
+            chan.socket.on('error', (function(parent, chan) {
+                return function(err) {
+                    if (debug >= 3) {
+                        console.log(logTS(), "Sending reset command to", parent.host, "for channel", chan.id, err);
+                    }
+                    parent.socket.write(frame_output(chan.id, true, CMD_RESET));
+                    if (debug >= 3) {
+                        console.log(logTS(), "Sent reset command to", parent.host, "for channel", chan.id);
+                    }
+                };
+            })(parent, chan));
+
+        }
+        else if (isCmd(frame.buff, CMD_CLOSE) ||
             isCmd(frame.buff, CMD_RESET) ||
             isCmd(frame.buff, CMD_SHUTDOWN)) {
-      if(chan.socket) {
-        chan.socket.end();
-        chan.socket.destroy();
-        chan.socket = null;
-        chan = parent.channels[frame.channel_id] = { id: chan.id };
-      }
-    }
-  }
-  else {
-    if(chan.socket) {
-      if(debug >= 3) console.log('data to local on channel', chan.id);
-      chan.socket.write(frame.buff);
+
+            if (debug >= 2) {
+                console.log(logTS(), "close/reset/shutdown command received from", parent.host, "for channel", chan.id);
+            }
+            if (chan.socket) {
+                chan.socket.end();
+                chan.socket.destroy();
+                chan.socket = null;
+                chan = parent.channels[frame.channel_id] = { id: chan.id };
+            }
+            else {
+                console.error(logTS(), "warn: no chan.socket to close/reset/shutdown");
+            }
+        }
     }
     else {
-      if(debug >= 2) console.log('reset to remote on channel', chan.id);
-      parent.socket.write(frame_output(chan.id, true, CMD_RESET));
+        if (chan.socket) {
+            if (debug >= 3) {
+                console.log(logTS(), "Sending data to local for channel", chan.id);
+            }
+            chan.socket.write(frame.buff);
+            if (debug >= 3) {
+                console.log(logTS(), "Sent data to local for channel", chan.id);
+            }
+        }
+        else {
+            if (debug >= 3) {
+                console.log(logTS(), "Sending reset command to", parent.host, "for channel", chan.id);
+            }
+            parent.socket.write(frame_output(chan.id, true, CMD_RESET));
+            if (debug >= 3) {
+                console.log(logTS(), "Sent reset command to", parent.host, "for channel", chan.id);
+            }
+        }
     }
-  }
 }
 
 nc.prototype.reverse = function(name, host, port) {
-  this.start(function(parent) {
-    parent.buflist = [];
-    var b = new Buffer("REVERSE /" + name + " HTTP/1.1\r\n\r\n", 'utf8');
-    parent.socket.write(b);
-    parent.socket.addListener('data', function(buffer) {
-      parent.buflist.push(buffer);
-      try {
-        var frame;
-        while(null !== (frame = decode_frame(parent.buflist))) {
-          handle_frame(parent, frame, host, port);
+    this.start(function(err, parent) {
+        if (debug >= 2) {
+            console.log(logTS(), "tls.connect to", parent.host, "for", name, "local:", host, "port", port);
         }
-      }
-      catch(e) {
-        console.log(e, e.stack);
-        parent.reverse_cleanup();
-        parent.socket.end();
-      }
+        if (err !== null) {
+            console.error(logTS(), "resetting connection to", parent.host, err);
+            if (parent.socket) {
+                parent.socket.end();
+            }
+        }
+        parent.buflist = [];
+        var b = new Buffer("REVERSE /" + name + " HTTP/1.1\r\n\r\n", 'utf8');
+        parent.socket.write(b);
+        parent.socket.addListener('data', function(buffer) {
+            if (debug >= 3) {
+                console.log(logTS(), "Received data packet from", parent.host);
+            }
+            parent.commTracker.lastRx = Date.now();
+            parent.buflist.push(buffer);
+            try {
+                var frame;
+                while (null !== (frame = decode_frame(parent.buflist))) {
+                    handle_frame(parent, frame, host, port);
+                }
+            }
+            catch(e) {
+                console.error(lotTS(), "handling incoming packet from", parent.host, e, e.stack);
+                parent.stop();
+            }
+        });
     });
-  });
-}
+};
 
-exports.setCA =
-nc.prototype.setCA = function(file) {
-  https.globalAgent.options.ca = [ fs.readFileSync(file, {encoding:'utf8'}) ];
-}
+exports.setCA = nc.prototype.setCA = function(file) {
+    https.globalAgent.options.ca = [ fs.readFileSync(file, {encoding:'utf8'}) ];
+};
 
 exports.noit_connection = nc;
+
 exports.set_stats = function(external) {
-  if(external === undefined || external == null) return stats;
-  stats = external;
-  if(! ("global" in stats)) {
-    stats.global = {
-      connects: 0, connections: 0, closes: 0
-    };
-  }
-  return stats;
+    if (external === undefined || external == null) {
+        return stats;
+    }
+    stats = external;
+    if (! ("global" in stats)) {
+        stats.global = {
+            connects: 0, connections: 0, closes: 0
+        };
+    }
+    return stats;
 };
 
 exports.set_stats(stats);


### PR DESCRIPTION
some fairly large updates for reverse connection failure handling.

* ~~update the rhel init script to not drop NAD messages explicitly sent to stderr (for systemd systems)~~ reverted for time being.
* remove unused sys require
* add preference for tls.createSecureContext if available (crypto.createCredentials deprecated)
* update error messages preceding exit to go to stderr
* add retries with drift for setting up reverse
* add setTimeout to reverse socket
* add a watchdog (checking last times for rx/tx) for edge cases
* add retries with drift for re-establishing remote connection
* add extra debugging messages
* remove redundant require of util as sys
* try to push all connection/communications abnormalities through socket.end() to centralize handling of exceptions

