### PR TITLE
Alternatives for libdtrace with Node v4

### DIFF
--- a/node_modules/dtrace_aggr2/index.js
+++ b/node_modules/dtrace_aggr2/index.js
@@ -1,0 +1,198 @@
+/* eslint-env node, es6 */
+/* eslint-disable no-magic-numbers */
+
+'use strict';
+
+const spawn = require('child_process').spawn;
+
+function aggregateSamples(tgt, src) {
+    if (src === null) {
+        return;
+    }
+
+    for (const metric in src) {
+        if (!{}.hasOwnProperty.call(tgt, metric)) {
+            tgt[metric] = {}; // eslint-disable-line no-param-reassign
+        }
+
+        const srcSamples = src[metric];
+        const tgtSamples = tgt[metric];
+
+        for (const sample in srcSamples) {
+            if (!{}.hasOwnProperty.call(tgtSamples, sample)) {
+                tgtSamples[sample] = 0;
+            }
+            tgtSamples[sample] += srcSamples[sample];
+        }
+    }
+}
+
+function makeHistogram(samples) {
+    const ret = [];
+
+    for (const key in samples) { // eslint-disable-line guard-for-in
+        ret.push(`H[${key}]=${samples[key]}`);
+    }
+
+    return ret;
+}
+
+module.exports = class Dtrace {
+
+    constructor(script) {
+
+        if (script === null || typeof script === 'undefined') {
+            throw new Error('Script is a required parameter for Dtrace class');
+        }
+
+        this.dtracePath = '/usr/sbin/dtrace';
+        this.dtrace = null;
+        this.script = script;
+
+        // the 'script' is inline if it is not an explicit path
+        this.inline = this.script.substr(0, 1) !== '/';
+
+        this.buffer = null;
+        this.lines = null;
+        this.windows = [];
+        this.cleaner = null;
+
+        for (let i = 0; i < 60; i++) {
+            this.windows.push(null);
+        }
+    }
+
+    start() {
+        const self = this;
+
+        const dtraceArgs = [ '-q' ];
+
+        if (this.inline) {
+            dtraceArgs.push('-n');
+        }
+        else {
+            dtraceArgs.push('-s');
+        }
+
+        dtraceArgs.push(this.script);
+
+        this.buffer = '';
+        this.dtrace = spawn(this.dtracePath, dtraceArgs);
+        this.lines = [];
+
+        this.dtrace.on('exit', (code, signal) => {
+            console.error(`${self.script} exited with code ${code} signal ${signal}`);
+            setTimeout(() => {
+                self.start();
+            }, 1000);
+        });
+
+        this.dtrace.stderr.on('data', (buff) => {
+            console.error(buff.toString());
+        });
+
+        this.dtrace.stdout.on('data', (chunk) => {
+            self.buffer += chunk;
+
+            /* split into lines, keeping leftovers */
+
+            const buffLines = self.buffer.split('\n');
+
+            if (buffLines[buffLines.length - 1] === '') { // eslint-disable-line no-magic-numbers
+                self.buffer = '';
+            }
+            else {
+                self.buffer = buffLines.pop();
+            }
+
+            for (let i = 0; i < buffLines.length; i++) {
+
+                const buffLine = buffLines[i].replace(/[\s@]+/g, '');
+
+                if (buffLine.substr(0, 1) !== '>') {
+                    self.lines.push(buffLine);
+                }
+                else if (buffLine.substr(0, 6) === '>START') {
+                    self.lines = [];
+                }
+                else if (buffLine.substr(0, 4) === '>END') {
+                    const currTimestamp = Math.floor(new Date() / 1000);
+                    let metricKey = null;
+                    const metrics = {};
+
+                    if (self.lastTimestamp === null) {
+                        self.lastTimestamp = currTimestamp;
+                    }
+                    if (currTimestamp - self.lastTimestamp >= 60) {
+                        for (let j = 0; j < 60; j++) {
+                            self.windows[j] = null;
+                        }
+                    }
+                    else {
+                        for (let j = self.lastTimestamp + 1; j < currTimestamp; j++) {
+                            self.windows[j % 60] = null;
+                        }
+                    }
+
+                    for (let j = 0; j < self.lines.length; j++) {
+                        const line = self.lines[j];
+                        let matches = null;
+
+                        matches = line.match(/^=(.+)$/);
+                        if (matches !== null) {
+                            metricKey = matches[1];
+                            continue;
+                        }
+
+                        if (metricKey === null || currTimestamp === null) {
+                            continue;
+                        }
+
+                        matches = line.match(/\d+|\d+/);
+                        if (matches !== null) {
+                            const aggSample = line.split('|');
+                            const latency = aggSample[0]; // used as a object attribute (string)
+                            const count = parseInt(aggSample[1], 10);
+
+                            if (count === 0) {
+                                continue;
+                            }
+                            if (!{}.hasOwnProperty.call(metrics, metricKey)) {
+                                metrics[metricKey] = {};
+                            }
+                            metrics[metricKey][latency] = count;
+                        }
+                    }
+
+                    const windowIdx = currTimestamp % 60;
+
+                    self.windows[windowIdx] = null;
+                    if (self.lines.length > 0) {
+                        self.windows[windowIdx] = metrics;
+                        self.lastTimestamp = currTimestamp;
+                    }
+                }
+            }
+        });
+    }
+
+    flush(numSamples) {
+        const currTimestamp = Math.floor(new Date() / 1000);
+        const startTimestamp = currTimestamp - numSamples;
+        const aggregates = {};
+        const histograms = {};
+
+        for (let i = startTimestamp; i <= this.lastTimestamp; i++) {
+            aggregateSamples(aggregates, this.windows[i % 60]);
+        }
+
+        for (const key in aggregates) { // eslint-disable-line guard-for-in
+            histograms[key] = { // eslint-disable-line quote-props
+                '_type': 'n',
+                '_value': makeHistogram(aggregates[key])
+            };
+        }
+
+        return histograms;
+    }
+};

--- a/plugins/illumos/fq.dtrace
+++ b/plugins/illumos/fq.dtrace
@@ -1,0 +1,15 @@
+#!/usr/sbin/dtrace -s
+#pragma D option quiet
+fq*:::message-deliver
+{
+    @l[strjoin(substr(args[0]->pretty,0,index(args[0]->pretty,"/")), "`latency_ns")] = llquantize(args[2]->latency,10,0,9,100);
+    @l["payload_len"] = llquantize(args[2]->payload_len,10,0,9,100);
+}
+tick-1sec
+{
+    printf(">START\n");
+    printa("=%s%@d\n", @l);
+    printf(">END\n");
+
+    trunc(@l);
+}

--- a/plugins/illumos/fq2.js
+++ b/plugins/illumos/fq2.js
@@ -1,0 +1,98 @@
+/* eslint-env node, es6 */
+
+'use strict';
+
+/*
+This plugin requires node v4.4+ (if the version of node installed is v0.10, use the io.js plugin).
+
+To use this module the user NAD runs as needs privileges to run DTrace.
+
+By default NAD runs as the unprivileged user 'nobody'. The 'nobody' user, by default,
+cannot run dtrace. What additional privileges are required can be displayed by running
+'ppriv -eD /opt/circonus/etc/node\-agent.d/illumos/fq.dtrace' as user nobody. The final
+attempt will simply yield an error 'dtrace: failed to initialize dtrace: DTrace
+requires additional privileges' which indicates the 'dtrace_kernel' privilege
+is required, 'kernel' because this plugin tracks system-wide fq events.
+
+Adding a line such as the following to /etc/user_attr will add the two privileges
+required (dtrace_kernel and file_dac_read) in a default OmniOS install. Different
+OSes and/or local security modfications may require different privileges:
+
+nobody::::type=normal;defaultpriv=basic,dtrace_kernel,file_dac_read
+
+Note: if there is already a line for nobody, modify it by adding the additional privileges.
+
+### enabling the plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Enable the plugin:
+
+cd /opt/circonus/etc/node-agent.d
+ln -s illumous/fq2.js fq.js
+
+3. Add additional privileges for nobody if not already done. (see above)
+
+4. Enable NAD:
+
+svcadm enable nad
+
+
+### disabling the plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Remove the symlink for the plugin:
+
+cd /opt/circonus/etc/node-agent.d
+rm fq.js
+
+3. Remove the additional privileges for nobody that were added to /etc/user_attr.
+   If a line was added, remove it. If an existing line was modified, remove the modifications.
+
+4. Enable NAD:
+
+svcadm enable nad
+
+*/
+
+const path = require('path');
+const Dtrace = require('dtrace_aggr2');
+
+const DEFAULT_SAMPLES = 60;
+const MILLISECOND = 1000;
+
+let singleton = null;
+
+module.exports = class FQ {
+    constructor() {
+        if (singleton !== null) {
+            return singleton;
+        }
+
+        this.dtrace = new Dtrace(path.resolve(path.join(__dirname, 'fq.dtrace')));
+        this.dtrace.start();
+
+        singleton = this; // eslint-disable-line consistent-this
+
+        return singleton;
+    }
+
+    run(details, cb, req, args, instance) { // eslint-disable-line max-params
+        let samples = DEFAULT_SAMPLES;
+
+        if (req) {
+            samples = Math.floor(req.headers['x-reconnoiter-period'] / MILLISECOND);
+        }
+
+        const metrics = this.dtrace.flush(samples);
+
+        cb(details, metrics, instance); // eslint-disable-line callback-return
+        details.running = false; // eslint-disable-line no-param-reassign
+
+    }
+};

--- a/plugins/illumos/io.dtrace
+++ b/plugins/illumos/io.dtrace
@@ -1,0 +1,24 @@
+#!/usr/sbin/dtrace -s
+#pragma D option quiet
+io:::start
+{
+    ts[arg0] = timestamp;
+}
+io:::done
+/this->ts = ts[arg0]/
+{
+    this->delta = timestamp - this->ts;
+    this->us = this->delta / 1000;
+    @l[strjoin(args[1]->dev_statname,strjoin("`",args[0]->b_flags & B_READ ? "read_latency_us" : "write_latency_us"))] = llquantize(this->us, 10, 0, 6, 100);
+    @l[strjoin(args[1]->dev_statname,"`latency_us")] = llquantize(this->us, 10, 0, 6, 100);
+    @l[strjoin(args[1]->dev_name,"`latency_us")] = llquantize(this->us, 10, 0, 6, 100);
+    ts[arg0] = 0;
+}
+tick-1sec
+{
+    printf(">START\n");
+    printa("=%s%@d\n", @l);
+    printf(">END\n");
+    
+    trunc(@l);
+}

--- a/plugins/illumos/io2.js
+++ b/plugins/illumos/io2.js
@@ -1,0 +1,98 @@
+/* eslint-env node, es6 */
+
+'use strict';
+
+/*
+This plugin requires node v4.4+ (if the version of node installed is v0.10, use the io.js plugin).
+
+To use this module the user NAD runs as needs privileges to run DTrace.
+
+By default NAD runs as the unprivileged user 'nobody'. The 'nobody' user, by default,
+cannot run dtrace. What additional privileges are required can be displayed by running
+'ppriv -eD /opt/circonus/etc/node\-agent.d/illumos/io.dtrace' as user nobody. The final
+attempt will simply yield an error 'dtrace: failed to initialize dtrace: DTrace
+requires additional privileges' which indicates the 'dtrace_kernel' privilege
+is required, 'kernel' because this plugin tracks system-wide IO.
+
+Adding a line such as the following to /etc/user_attr will add the two privileges
+required (dtrace_kernel and file_dac_read) in a default OmniOS install. Different
+OSes and/or local security modfications may require different privileges:
+
+nobody::::type=normal;defaultpriv=basic,dtrace_kernel,file_dac_read
+
+Note: if there is already a line for nobody, modify it by adding the additional privileges.
+
+### enabling the IO plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Enable the IO plugin:
+
+cd /opt/circonus/etc/node-agent.d
+ln -s illumous/io2.js io.js
+
+3. Add additional privileges for nobody if not already done. (see above)
+
+4. Enable NAD:
+
+svcadm enable nad
+
+
+### disabling the IO plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Remove the symlink for the IO plugin:
+
+cd /opt/circonus/etc/node-agent.d
+rm io.js
+
+3. Remove the additional privileges for nobody that were added to /etc/user_attr.
+   If a line was added, remove it. If an existing line was modified, remove the modifications.
+
+4. Enable NAD:
+
+svcadm enable nad
+
+*/
+
+const path = require('path');
+const Dtrace = require('dtrace_aggr2');
+
+const DEFAULT_SAMPLES = 60;
+const MILLISECOND = 1000;
+
+let singleton = null;
+
+module.exports = class IO {
+    constructor() {
+        if (singleton !== null) {
+            return singleton;
+        }
+
+        this.dtrace = new Dtrace(path.resolve(path.join(__dirname, 'io.dtrace')));
+        this.dtrace.start();
+
+        singleton = this; // eslint-disable-line consistent-this
+
+        return singleton;
+    }
+
+    run(details, cb, req, args, instance) { // eslint-disable-line max-params
+        let samples = DEFAULT_SAMPLES;
+
+        if (req) {
+            samples = Math.floor(req.headers['x-reconnoiter-period'] / MILLISECOND);
+        }
+
+        const metrics = this.dtrace.flush(samples);
+
+        cb(details, metrics, instance); // eslint-disable-line callback-return
+        details.running = false; // eslint-disable-line no-param-reassign
+
+    }
+};

--- a/plugins/illumos/syscall2.js
+++ b/plugins/illumos/syscall2.js
@@ -1,0 +1,133 @@
+/* eslint-env node, es6 */
+/* eslint-disable no-magic-numbers */
+
+'use strict';
+
+/*
+This plugin requires node v4.4+ (if the version of node installed is v0.10, use the io.js plugin).
+
+To use this module the user NAD runs as needs privileges to run DTrace.
+
+By default NAD runs as the unprivileged user 'nobody'. The 'nobody' user, by default,
+cannot run dtrace.
+
+Adding a line such as the following to /etc/user_attr will add the two privileges
+required (dtrace_kernel and file_dac_read) in a default OmniOS install. Different
+OSes and/or local security modfications may require different privileges:
+
+nobody::::type=normal;defaultpriv=basic,dtrace_kernel,file_dac_read
+
+Note: if there is already a line for nobody, modify it by adding the additional privileges.
+
+
+### Configuration ###
+
+To track the syscalls for a specific process. Create a configuration file
+/opt/circonus/etc/syscall2.json, for example:
+{
+  "execname": "node"
+}
+
+Will collect syscall metrics only for process(es) where the execname is 'node'.
+
+### enabling the plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Enable the plugin:
+
+cd /opt/circonus/etc/node-agent.d
+ln -s illumous/syscall2.js syscall.js
+
+3. Add additional privileges for nobody if not already done. (see above)
+
+4. Enable NAD:
+
+svcadm enable nad
+
+
+### disabling the plugin ###
+
+1. Disable NAD:
+
+svcadm disable nad
+
+2. Remove the symlink for the plugin:
+
+cd /opt/circonus/etc/node-agent.d
+rm syscall.js
+
+3. Remove the additional privileges for nobody that were added to /etc/user_attr.
+   If a line was added, remove it. If an existing line was modified, remove the modifications.
+
+4. Enable NAD:
+
+svcadm enable nad
+
+*/
+
+const path = require('path');
+const Dtrace = require('dtrace_aggr2');
+
+const DEFAULT_SAMPLES = 60;
+const MILLISECOND = 1000;
+
+let singleton = null;
+
+module.exports = class Syscall {
+    constructor() {
+        if (singleton !== null) {
+            return singleton;
+        }
+
+        const cfgName = `${path.basename(__filename, '.js')}.json`; // e.g. syscall2.json
+        const cfgFile = path.resolve(path.join(__dirname, '..', '..', cfgName));
+
+        let execName = null;
+
+        try {
+            const cfg = require(cfgFile); // eslint-disable-line global-require
+
+            if ({}.hasOwnProperty.call(cfg, 'execname')) {
+                execName = cfg.execname;
+            }
+        }
+        catch (err) {
+            console.error(err);
+        }
+
+        let script = '';
+
+        if (execName === null) {
+            script = 'syscall:::entry{self->start=timestamp;}syscall:::return/self->start/{@l[strjoin(probefunc,"`latency_us")] = llquantize((timestamp-self->start)/1000, 10, 0, 6, 100); self->start = 0;}'; // eslint-disable-line max-len
+        }
+        else {
+            script = `syscall:::entry/execname=="${execName}"/{self->start=timestamp;}syscall:::return/self->start/{@l[strjoin(strjoin(execname,"\`"),strjoin(probefunc,"\`latency_us"))] = llquantize((timestamp-self->start)/1000, 10, 0, 6, 100); self->start = 0;}`; // eslint-disable-line max-len
+        }
+
+        script += 'tick-1sec{printf(">START\\n");printa("=%s%@d\\n", @l);printf(">END\\n");trunc(@l);}';
+
+        this.dtrace = new Dtrace(script);
+        this.dtrace.start();
+
+        singleton = this; // eslint-disable-line consistent-this
+
+        return singleton;
+    }
+
+    run(details, cb, req, args, instance) { // eslint-disable-line max-params
+        let samples = DEFAULT_SAMPLES;
+
+        if (req) {
+            samples = Math.floor(req.headers['x-reconnoiter-period'] / MILLISECOND);
+        }
+
+        const metrics = this.dtrace.flush(samples);
+
+        cb(details, metrics, instance); // eslint-disable-line callback-return
+        details.running = false; // eslint-disable-line no-param-reassign
+
+    }
+};


### PR DESCRIPTION
io, fq, syscall alternatives which use dtrace command and parse output rather than libdtrace for nodejs v4+ installs.