### PR TITLE
alternative to if.sh using link:

### DIFF
--- a/plugins/illumos/iflink.sh
+++ b/plugins/illumos/iflink.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu
+
+KSTAT="/usr/bin/kstat"
+SED="/usr/gnu/bin/sed"
+
+[[ ! -x $KSTAT ]] && {
+    echo "kstat '$KSTAT' not found.";
+    exit 1;
+}
+
+[[ ! -x $SED ]] && {
+    echo "sed '$SED' not found.";
+    exit 1;
+}
+
+kstat_opts="-p link:"
+
+$KSTAT $kstat_opts | $SED -e '/:\(class\|crtime\|snaptime\)/d; s/^link:[0-9]*://; s/:/`/g; s/\t/\tL\t/'


### PR DESCRIPTION
an alternative to if.sh, uses link: module producing only one instance of each metric. (e.g. rbytes, ipackets, etc.)

```sh
omnios-test:/opt/circonus/etc/node-agent.d$ ./iflink.sh
e1000g0`brdcstrcv       L       0
e1000g0`brdcstxmt       L       10
e1000g0`collisions      L       0
e1000g0`ierrors L       0
e1000g0`ifspeed L       1000000000
e1000g0`ipackets        L       1449
e1000g0`ipackets64      L       1449
e1000g0`link_duplex     L       2
e1000g0`link_state      L       1
e1000g0`multircv        L       0
e1000g0`multixmt        L       0
e1000g0`norcvbuf        L       0
e1000g0`noxmtbuf        L       0
e1000g0`obytes  L       98880
e1000g0`obytes64        L       98880
e1000g0`oerrors L       0
e1000g0`opackets        L       893
e1000g0`opackets64      L       893
e1000g0`rbytes  L       123316
e1000g0`rbytes64        L       123316
e1000g0`unknowns        L       0
```