### PR TITLE
readlink vs realpath, retry w/stepped backoff on rate limit response

### DIFF
--- a/node_modules/circonusapi2/index.js
+++ b/node_modules/circonusapi2/index.js
@@ -19,6 +19,7 @@
 
 var qs = require('querystring');
 var ProxyAgent = require('https-proxy-agent');
+var zlib = require('zlib');
 
 var singleton = null;
 var api = null;
@@ -134,41 +135,99 @@ api.prototype.do_request = function(options, callback) {
     }
 
     var req = this.protocol.request(options, function(res) {
-        var body = '';
+        var data = [];
 
         res.on('data', function(chunk) {
-            body += chunk;
+            data.push(chunk);
         });
 
         res.on('end', function() {
+            // try again... on rate limit or internal (server-side, hopefully recoverable) error
+            if (res.statusCode === 429 || res.statusCode === 500) {
+                if (options.circapi.retry < options.circapi.retry_backoff.length) {
+                    setTimeout(function() {
+                        self.do_request(options, callback);
+                    }, options.circapi.retry_backoff[options.circapi.retry]);
+                    options.circapi.retry += 1;
+                } else {
+                    callback(res.statusCode, new Error('Giving up after '+options.circapi.retry+' attempts'), null, null);
+                    return;
+                }
+            }
+
+            // success, no content
+            if (res.statusCode === 204) {
+                callback(res.statusCode, null, null, null);
+                return;
+            }
+
+            var buffer = Buffer.concat(data);
+            var encoding = res.headers['content-encoding'];
             var err_msg = null;
+            var body = null;
+
+            if (data.length === 0) {
+                err_msg = new Error('No data returned, 0 length body.');
+            } else if (encoding === 'gzip') {
+                try {
+                    body = zlib.gunzipSync(buffer).toString();
+                } catch (gzipErr) {
+                    err_msg = gzipErr;
+                }
+            } else if (encoding === 'deflate') {
+                try {
+                    body = zlib.deflateSync(buffer).toString();
+                } catch (deflateErr) {
+                    err_msg = deflateErr;
+                }
+            } else {
+                body = buffer.toString();
+            }
 
             if (self.verbose) {
                 console.error('RESPONSE ' + res.statusCode + ':');
                 console.error(body);
             }
 
-      // If this isn't a 200 level, extract the message from the body
+            if (err_msg !== null) {
+                callback(res.statusCode, err_msg, null, body);
+                return;
+            }
+
+            // If this isn't a 200 level, extract the message from the body
             if (res.statusCode < 200 || res.statusCode > 299) {
                 try {
                     err_msg = JSON.parse(body).message;
                 } catch (err) {
                     err_msg = 'An error occurred, but the body could not be parsed: ' + err;
                 }
+                callback(res.statusCode, err_msg, null, body);
+                return;
             }
+
             var parsed = null;
-            try { if (body) parsed = JSON.parse(body); } catch (unused) {}
+
+            try {
+                if (body) {
+                    parsed = JSON.parse(body);
+                }
+            } catch (parseErr) {
+                err_msg = new Error('Error parsing body');
+                err_msg.detail = parseErr;
+                err_msg.body = body;
+            }
+
             callback(res.statusCode, err_msg, parsed, body);
         });
     });
 
     req.on('error', function(e) {
-        if (e.code === 'ECONNRESET' && options.circapi.retry < 5) {
-            options.circapi.retry += 1;
-            // sleep 1 second and try again, probably hit the rate limit
+        if (e.code === 'ECONNRESET' && options.circapi.retry < options.circapi.retry_backoff.length) {
+            // sleep and try again, hopefully a recoverable error
             setTimeout(function() {
                 self.do_request(options, callback);
-            }, 1000 * options.circapi.retry);
+            }, options.circapi.retry_backoff[options.circapi.retry]);
+            options.circapi.retry += 1;
         } else {
             callback(null, e.message, null);
         }
@@ -198,16 +257,45 @@ api.prototype.get_request_options = function(method, endpoint, data) {
         headers: {
             'X-Circonus-Auth-Token': this.authtoken,
             'X-Circonus-App-Name': this.appname,
-            'Accept': 'application/json'
+            'Accept': 'application/json',
+            'Accept-Encoding': 'gzip,deflate'
         },
         circapi: {
             retry: 0,
+            retry_backoff: [
+                null,       // 0 first attempt
+                1 * 1000,   // 1, wait 1 second and try again
+                2 * 1000,   // 2, wait 2 seconds and try again
+                4 * 1000,   // 3, wait 4 seconds and try again
+                8 * 1000,   // 4, wait 8 seconds and try again
+                16 * 1000,  // 5, wait 16 seconds and try again
+                32 * 1000   // 6, wait 32 seconds and retry again then give up if it fails
+            ],
             data: null
         }
     };
 
     if (this.proxyServer !== null) {
         options.agent = new ProxyAgent(this.proxyServer);
+    }
+
+    if ((/^v[46]/).test(process.version)) {
+
+        // currently 2016-10-27T16:01:42Z, these settings seem to be
+        // necessary to prevent http/https requests from intermittently
+        // emitting an end event prior to all content being received
+        // when communicating with the API. at least until the actual
+        // root cause can be determined.
+
+        if (!{}.hasOwnProperty.call(options, 'agent') || options.agent === false) {
+            options.agent = new this.protocol.Agent();
+        }
+
+        options.agent.keepAlive = false;
+        options.agent.keepAliveMsecs = 0;
+        options.agent.maxSockets = 1;
+        options.agent.maxFreeSockets = 1;
+        options.agent.maxCachedSessions = 0;
     }
 
     options.circapi.data = data;

--- a/plugins/postgresql/pg_bgwriter.sh
+++ b/plugins/postgresql/pg_bgwriter.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_cache.sh
+++ b/plugins/postgresql/pg_cache.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_connections.sh
+++ b/plugins/postgresql/pg_connections.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 IFS=','

--- a/plugins/postgresql/pg_db_size.sh
+++ b/plugins/postgresql/pg_db_size.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_functions.sh
+++ b/plugins/postgresql/pg_functions.sh
@@ -18,7 +18,7 @@ fi
 : ${PGDATABASE:=postgres}
 : ${PGPASS:=}
 : ${PGPORT:=5432}
-[[ -n ${PGPASS:-} ]] && export PGPASSWORD="$PGPASS"
+[[ -n ${PGPASS:-} && -z ${PGPASSWORD:-} ]] && export PGPASSWORD="$PGPASS"
 
 pg_functions=1
 

--- a/plugins/postgresql/pg_isready.sh
+++ b/plugins/postgresql/pg_isready.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 PGCMD=$(command -v pg_isready)

--- a/plugins/postgresql/pg_locks.sh
+++ b/plugins/postgresql/pg_locks.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 IFS=','

--- a/plugins/postgresql/pg_partitions.sh
+++ b/plugins/postgresql/pg_partitions.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 IFS=','

--- a/plugins/postgresql/pg_repl_lag.sh
+++ b/plugins/postgresql/pg_repl_lag.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_repl_slots.sh
+++ b/plugins/postgresql/pg_repl_slots.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_replication.sh
+++ b/plugins/postgresql/pg_replication.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 LINEBREAKS=$'\n\b'

--- a/plugins/postgresql/pg_table_stats.sh
+++ b/plugins/postgresql/pg_table_stats.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 IFS=','

--- a/plugins/postgresql/pg_transactions.sh
+++ b/plugins/postgresql/pg_transactions.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 IFS=','

--- a/plugins/postgresql/pg_vacuum.sh
+++ b/plugins/postgresql/pg_vacuum.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-plugin_dir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+plugin_dir=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 pgfuncs="${plugin_dir}/pg_functions.sh"
-[[ -f $pgfuncs ]] && source $pgfuncs
+[[ -f $pgfuncs ]] || { echo "Unable to find pg functions ${pgfuncs}"; exit 1; }
+source $pgfuncs
 [[ ${pg_functions:-0} -eq 0 ]] && { echo "Invalid plugin configuration."; exit 1; }
 
 vacuum_data=$($PSQL -U $PGUSER -d $PGDATABASE -p $PGPORT -w -F, -Atc "WITH max_age AS (SELECT 2000000000 as max_old_xid, setting AS autovacuum_freeze_max_age FROM pg_settings WHERE name = 'autovacuum_freeze_max_age'), per_database_stats AS (SELECT datname, m.max_old_xid::int, m.autovacuum_freeze_max_age::int, age(d.datfrozenxid) AS oldest_current_xid FROM pg_database d JOIN max_age m ON (true) WHERE d.datallowconn) SELECT 'autovac', max(oldest_current_xid) AS oldest_current_xid, max(ROUND(100*(oldest_current_xid/max_old_xid::float))) AS percent_towards_wraparound, max(ROUND(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) AS percent_towards_emergency_autovac FROM per_database_stats;")


### PR DESCRIPTION
postgresql plugin: use readlink to eliminate realpath in path issues

api: stepped backoff/retry for 429 and 500s, add gzip/deflate response support, fix for premature end event firing.