### PR TITLE
v2.0.2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nad",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "Circonus Node Agent",

--- a/packaging/omnibus-rpm.spec.in
+++ b/packaging/omnibus-rpm.spec.in
@@ -5,7 +5,13 @@
 
 # perl is *optional* not required
 # rpmbuild autoreq will include it by default because of scripts with perl shebang
+%if 0%{?el7}
 %define __requires_exclude perl
+%endif
+%if 0%{?el6}
+# rpmbuild on el6 is pre-4.9, does not understand __requires_exclude
+AutoReq: 0
+%endif
 
 Name:		nad-omnibus
 Version:	%{rversion}


### PR DESCRIPTION
stock centos6 rpmbuild v4.8 does not recognize `__requires_exclude` to remove perl from dependencies.  