### PR TITLE
v2.0.3 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,24 +321,24 @@ Place configuration options in a file, the default is `/opt/circonus/nad/etc/sta
 
 The default nad-statsd configuration is:
 
-```js
+```json
 {
-    servers: [
+    "servers": [
         {
-            server: 'udp',
-            address: '127.0.0.1',
-            port: 8125
+            "server": "udp",
+            "address": "127.0.0.1",
+            "port": 8125
         }
     ],
-    flush_interval: 10000,
-    group_check_id: null,
-    group_key: 'group.',
-    group_counter_op: 'sum',
-    group_gauge_op: 'average',
-    group_set_op: 'sum',
-    host_key: null,
-    host_category: 'statsd',
-    send_process_stats: true    
+    "flush_interval": 10000,
+    "group_check_id": null,
+    "group_key": "group.",
+    "group_counter_op": "sum",
+    "group_gauge_op": "average",
+    "group_set_op": "sum",
+    "host_key": null,
+    "host_category": "statsd",
+    "send_process_stats": true    
 }
 ```
 

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -774,7 +774,7 @@ class Plugins {
         if (plugin.is_native) {
             plugin.native_obj.run(plugin,
                                   (_plugin, _metrics, _plugin_instance) => {
-                                      _plugin.last_result[_plugin_instance] = _metrics; // eslint-disable-line no-param-reassign
+                                      _plugin.last_result = _metrics; // eslint-disable-line no-param-reassign
                                       cb(_plugin, _metrics, _plugin_instance);
                                   }, req, args, plugin_instance);
 
@@ -828,11 +828,15 @@ class Plugins {
             try {
                 results = JSON.parse(proc_data.lines.join(' '));
             } catch (err) { // eslint-disable-line no-unused-vars
-                // ignore err ... try the tab delim format
-                for (const line of proc_data.lines) {
-                    const parts = (/^\s*(metric\s+)?(\S+)\s+(string|int|float|[iIlLns])(\s*)(.*)$/).exec(line);
+                // try the tab delim format
+                try {
+                    for (const line of proc_data.lines) {
+                        const parts = (/^\s*(metric\s+)?(\S+)\s+(string|int|float|[iIlLns])(\s*)(.*)$/).exec(line);
 
-                    if (parts) {
+                        if (!parts) {
+                            throw err;
+                        }
+
                         const name = parts[2];
                         let type = parts[3];
                         const space = parts[4];
@@ -858,11 +862,13 @@ class Plugins {
                             };
                         }
                     }
+                } catch (parseErr) {
+                    log.warn(parseErr, 'unable to parse plugin output');
                 }
             }
 
             // remember the past results
-            _plugin.last_result[_plugin_instance] = results; // eslint-disable-line no-param-reassign
+            _plugin.last_result = results; // eslint-disable-line no-param-reassign
 
             // execute the callback
             _cb(_plugin, results, _plugin_instance);
@@ -918,6 +924,7 @@ class Plugins {
                 } else {
                     // if a blank line, process collected lines
                     handle_output(plugin, cb, plugin_instance);
+                    proc_data.lines = [];
                 }
 
                 // discard this line from the buffer we're using between

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -334,7 +334,9 @@ class Scanner {
                 def.generation = self.generation;
                 def.command = plugin_status.file_name;
                 def.is_native = plugin_status.is_native;
-                def.running = false;
+                def.running = plugin_status.id in plugin_list
+                    ? plugin_list[plugin_status.id].running // maintain running state if updating
+                    : false;
                 def.last_stat = plugin_status.stat;
                 def.config = null;
                 def.config_file = path.resolve(path.join(self.plugin_dir, `${def.id}.json`));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nad",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "Circonus Node Agent",

--- a/plugins/linux/bccbpf/iolatency.py
+++ b/plugins/linux/bccbpf/iolatency.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 import argparse
 import json
+import sys
 from time import sleep
 #, strftime
 
@@ -124,10 +125,11 @@ def main():
             if dsk not in metrics:
                 metrics[dsk] = {'_type': 'n', '_value': []}
 
-            metrics[dsk]['_value'].append('[%.2f]=%d' % (bkt, cnt))
+            metrics[dsk]['_value'].append('H[%.2f]=%d' % (bkt, cnt))
 
         if len(metrics) > 0:
             print(json.dumps(metrics), '\n')
+            sys.stdout.flush()
         dist.clear()
 
 if __name__ == "__main__":

--- a/plugins/linux/bccbpf/iolatency.py
+++ b/plugins/linux/bccbpf/iolatency.py
@@ -107,7 +107,7 @@ def main():
     bpf.attach_kprobe(event="blk_account_io_completion", fn_name="trace_req_completion")
 
     # output
-    interval = 5
+    interval = 60
     dist = bpf.get_table("dist")
     while 1:
         try:
@@ -130,6 +130,7 @@ def main():
         if len(metrics) > 0:
             print(json.dumps(metrics), '\n')
             sys.stdout.flush()
+
         dist.clear()
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Plugins
   * fix: maintain running state if updating on rescans - prevent starting long running plugins multiple times.
   * fix: reset lines after processing when blank line triggers.
   * fix: duplicate instance name on last_results.
   * upd: plugin output expose parsing errors better.
1. BCC iolatency plugin
   * fix: add 'H' to metric bucket expression.
   * fix: flush stdout after print, force nad to process line.
   * upd: increase interval to 60
1. doc: statsd
   * fix: example statsd config should be valid json