### PR TITLE
Better parsing/exit errors for plugins

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -844,7 +844,11 @@ class Plugins {
                         }
                     }
                 } catch (parseErr) {
-                    log.warn(parseErr, 'unable to parse plugin output');
+                    log.warn({
+                        error  : parseErr.message,
+                        output : proc_data.lines,
+                        plugin : _plugin_instance
+                    }, 'unable to parse plugin output');
                 }
             }
 

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -747,7 +747,10 @@ class Plugins {
             // blank line
             lines: [],
 
-            options: {}
+            options: {},
+
+            // output from stderr
+            stderr: ''
         };
 
         // if this is a native plugin - call plugin's run() method
@@ -815,7 +818,7 @@ class Plugins {
                         const parts = (/^\s*(metric\s+)?(\S+)\s+(string|int|float|[iIlLns])(\s*)(.*)$/).exec(line);
 
                         if (!parts) {
-                            throw err;
+                            throw new Error(`JSON(${err.message}), TAB_DELIMITED(does not match pattern)`);
                         }
 
                         const name = parts[2];
@@ -867,6 +870,10 @@ class Plugins {
         // our between callback buffer)
         cmd.stdout.on('end', () => {
             handle_output(plugin, cb, plugin_instance);
+        });
+
+        cmd.stderr.on('data', (chunk) => {
+            proc_data.stderr += chunk;
         });
 
         // hook up an anonymous function to the process to be called
@@ -925,10 +932,11 @@ class Plugins {
         cmd.on('exit', (code, signal) => {
             if (code !== 0) {
                 log.warn({
-                    cmd : plugin.command,
+                    cmd    : plugin.command,
                     code,
-                    id  : plugin_instance,
-                    signal
+                    id     : plugin_instance,
+                    signal,
+                    stderr : proc_data.stderr
                 }, 'plugin exit code non-zero');
             }
             plugin.running = false; // eslint-disable-line no-param-reassign

--- a/plugins/linux/src/fs.c
+++ b/plugins/linux/src/fs.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
             df_pct = (used * 100) / adj + ((used * 100) % adj != 0);
            	pct = 100.0*(double)used/(double)adj;
         }
-        printf("%s`df_used_percent\tL\t%0.2f\n", mnt.mnt_dir, df_pct);
-        printf("%s`used_percent\tL\t%0.2f\n", mnt.mnt_dir, pct);
+        printf("%s`df_used_percent\tn\t%0.2f\n", mnt.mnt_dir, df_pct);
+        printf("%s`used_percent\tn\t%0.2f\n", mnt.mnt_dir, pct);
 
         pct = 0;
         df_pct = 0;
@@ -64,8 +64,8 @@ int main(int argc, char **argv) {
             df_pct = (used * 100) / buf.f_files + ((used * 100) % buf.f_files != 0);
             pct = 100.0*(double)(buf.f_files - buf.f_ffree)/(double)buf.f_files;
         }
-        printf("%s`df_used_inode_percent\tL\t%0.2f\n", mnt.mnt_dir, df_pct);
-        printf("%s`used_inode_percent\tL\t%0.2f\n", mnt.mnt_dir, pct);    }
+        printf("%s`df_used_inode_percent\tn\t%0.2f\n", mnt.mnt_dir, df_pct);
+        printf("%s`used_inode_percent\tn\t%0.2f\n", mnt.mnt_dir, pct);    }
   }
   exit(0);
 }


### PR DESCRIPTION
* improve the error message when parsing fails on plugin output
```
[2017-08-25T17:08:28.133Z] WARN (nad/3133 on cosi-u16-c4ec3346f): unable to parse plugin output
    module: "plugins"
    error: "JSON(Unexpected token m in JSON at position 0), TAB_DELIMITED(does not match pattern)"
    output: [
      "metric_name1\ts\tfooOK",
      "metric_name2\tt\tbarBadType"
    ]
    plugin: "errtest"
```

* add output from stderr to log messages when a plugin exits with a code > 0
```
[2017-08-25T17:08:28.137Z] WARN (nad/3133 on cosi-u16-c4ec3346f): plugin exit code non-zero
    module: "plugins"
    cmd: "/opt/circonus/nad/etc/node-agent.d/errtest.sh"
    code: 1
    id: "errtest"
    signal: null
    stderr: "ERROR message sent to stderr\n"
```