### PR TITLE
Strip asterisk from name of down interfaces

### DIFF
--- a/plugins/freebsd/if.sh
+++ b/plugins/freebsd/if.sh
@@ -7,6 +7,7 @@
 ${BIN_NETSTAT} -i -b -n -W -f link | ${BIN_AWK} '{
     if ($1 == "Name") next;
     if ($1 ~ /^lo[0-9]/) next;
+    sub(/\*$/,"",$1);
     printf("%s`in_bytes\tL\t%d\n", $1, $8);
     printf("%s`in_packets\tL\t%d\n", $1, $5);
     printf("%s`in_errors\tL\t%d\n", $1, $6);


### PR DESCRIPTION
FreeBSD's netstat appends "*" to the names of interfaces that are
down. We should not include this in the name of the interface.