### PR TITLE
initial commit of ZFSonLinux plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ install-plugins:	install-dirs
 	rsync -a plugins/ $(DESTDIR)$(CONF)/
 
 install-modules:
-	rsync -a lib/* $(DESTDIR)$(NAD_LIB)
 	cp package.json $(DESTDIR)$(APP_DIR) && \
 		cd $(DESTDIR)$(APP_DIR) && \
 		PATH="$(PATH):$(DESTDIR)$(PREFIX)/bin" PREFIX= npm install --only=production --no-progress
+	rsync -a lib/* $(DESTDIR)$(NAD_LIB)
 
 install-illumos:	install
 	@# service manifest
@@ -104,7 +104,7 @@ install-linux:	install
 	./install-sh -c -m 0755 bin/nad-log.out $(DESTDIR)$(BIN)/nad-log
 	@# linux binaries and default plugins
 	cd $(DESTDIR)$(CONF)/linux ; $(MAKE)
-	cd $(DESTDIR)$(CONF) ; for f in cpu.sh disk.sh diskstats.sh fs.elf if.sh vm.sh ; do /bin/ln -sf linux/$$f ; done
+	cd $(DESTDIR)$(CONF) ; for f in cpu.sh disk.sh diskstats.sh fs.elf if.sh vm.sh zfs.sh ; do /bin/ln -sf linux/$$f ; done
 	cd $(DESTDIR)$(CONF) ; for f in loadavg.elf ; do /bin/ln -sf common/$$f ; done
 ifneq ($(wildcard /sbin/zpool),)
 	cd $(DESTDIR)$(CONF) ; /bin/ln -sf common/zpool.sh

--- a/plugins/linux/zfs.sh
+++ b/plugins/linux/zfs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# ZFSonLinux collector for nad
+#
+
+PROC_DIR=${PROC_DIR:=/proc/spl/kstat/zfs}
+
+# kstat-compatible files in /proc
+# depending on the ZFS version, these files may or may not exist, but that is ok
+#
+# for those kstat files that do exist, but aren't listed here:
+#   + vdev_cache_stats are effectively deprecated and will contain zeroes (boring)
+#   + xuio_stats -- XUIO interface on ZFSonLinux has no known consumer as of 1-Jan-2018
+GLOBAL_KSTAT_FILES="
+    abdstats
+    arcstats
+    dbufcachestats
+    dmu_tx
+    dnodestats
+    fm
+    vdev_mirror_stats
+    zfetchstats
+    zil
+"
+
+# ZFSonLinux currently only implements the KSTAT_DATA_UINT64 entries
+KSTAT_DATA_UINT64="4"
+
+for f in ${GLOBAL_KSTAT_FILES}
+do
+    filename=${PROC_DIR}/${f}
+    [[ -f ${filename} ]] || continue
+
+    while read -r line
+    do
+        a=(${line})
+        [[ ${#a[*]} != 3 ]] && continue
+        case ${a[1]} in
+            ${KSTAT_DATA_UINT64})  TYPE=L ;;
+            *)  continue ;;
+        esac
+        printf "%s\`%s\t%s\t%s\n" ${f} ${a[0]} $ ${a[2]}
+    done < ${filename}
+done
+
+# The "io" stats file contains the traditional KSTAT_TYPE_IO statistics in a
+# single row format.
+#
+# NB, if you notice rlentime == wlentime and find yourself looking at this code,
+# then be aware of https://github.com/zfsonlinux/spl/issues/651 and consider
+# the simple fix therein
+for io_stats in ${PROC_DIR}/*/io
+do
+    pool_dir=${io_stats%/*}
+    pool_name=${pool_dir##*/}
+    line_count=0
+    while read -r line
+    do
+        line_count=$((line_count + 1))
+        [[ ${line_count} == 2 ]] && header=(${line})
+        [[ ${line_count} < 3 ]] && continue
+        v=(${line})
+        index=0
+        for i in ${header[*]}
+        do
+            printf "zpool_io\`%s\`%s\tL\t%s\n" ${pool_name} ${header[${index}]} ${v[${index}]}
+            index=$((index + 1))
+        done
+        break
+    done < ${io_stats}
+done


### PR DESCRIPTION
initial commit of ZFSonLinux collector compatible with versions up to v0.7.5

re-order makefile's install-modules because npm install can remove NAD_LIB